### PR TITLE
Changed encryption to AES/GCM with additional authenticated data

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/metadata/EncryptionMetadata.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/metadata/EncryptionMetadata.java
@@ -21,21 +21,21 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-class EncryptionKeyMetadata {
+class EncryptionMetadata {
 
-    private final String key;
+    private final String encryptionMetadata;
 
     private final int version;
 
     @JsonCreator
-    public EncryptionKeyMetadata(@JsonProperty("key") final String key,
-                                 @JsonProperty("version") final int version) {
-        this.key = key;
+    public EncryptionMetadata(@JsonProperty("encryptionMetadata") final String encryptionMetadata,
+                              @JsonProperty("version") final int version) {
+        this.encryptionMetadata = encryptionMetadata;
         this.version = version;
     }
 
-    public String key() {
-        return key;
+    public String encryptionMetadata() {
+        return encryptionMetadata;
     }
 
     public int version() {

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/security/EncryptionKeyProvider.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/security/EncryptionKeyProvider.java
@@ -20,7 +20,6 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 
 import java.io.InputStream;
 import java.security.KeyPair;
@@ -37,7 +36,7 @@ public final class EncryptionKeyProvider
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionKeyProvider.class);
 
-    public static final int KEY_SIZE = 256;
+    public static final int KEY_SIZE = 512;
 
     private static final String CIPHER_TRANSFORMATION = "RSA/NONE/OAEPWithSHA3-512AndMGF1Padding";
 
@@ -79,10 +78,10 @@ public final class EncryptionKeyProvider
         }
     }
 
-    public SecretKey decryptKey(final byte[] bytes) {
+    public byte[] decryptKey(final byte[] bytes) {
         try {
             final var cipher = createDecryptingCipher(rsaKeyPair.getPrivate(), CIPHER_TRANSFORMATION);
-            return new SecretKeySpec(cipher.doFinal(bytes), "AES");
+            return cipher.doFinal(bytes);
         } catch (final IllegalBlockSizeException | BadPaddingException e) {
             throw new RuntimeException("Couldn't encrypt AES key", e);
         }

--- a/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/io/CryptoIOProviderTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/io/CryptoIOProviderTest.java
@@ -16,6 +16,8 @@
 
 package io.aiven.kafka.tiered.storage.commons.io;
 
+import javax.crypto.spec.SecretKeySpec;
+
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,8 +46,12 @@ public class CryptoIOProviderTest extends RsaKeyAwareTest {
                 Files.newInputStream(publicKeyPem),
                 Files.newInputStream(privateKeyPem)
         );
-        final var encryptionKey = encProvider.createKey();
-        cryptoIOProvider = new CryptoIOProvider(encryptionKey, BUFFER_SIZE);
+        final var key = encProvider.createKey();
+        final byte[] encryptionKey = new byte[32];
+        System.arraycopy(key.getEncoded(), 0, encryptionKey, 0, 32);
+        final byte[] aad = new byte[32];
+        System.arraycopy(key.getEncoded(), 32, encryptionKey, 0, 32);
+        cryptoIOProvider = new CryptoIOProvider(new SecretKeySpec(encryptionKey, "AES"), aad, BUFFER_SIZE);
     }
 
     @Test

--- a/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/security/EncryptionKeyProviderTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/security/EncryptionKeyProviderTest.java
@@ -16,6 +16,8 @@
 
 package io.aiven.kafka.tiered.storage.commons.security;
 
+import javax.crypto.spec.SecretKeySpec;
+
 import java.io.IOException;
 import java.nio.file.Files;
 
@@ -23,8 +25,7 @@ import io.aiven.kafka.tiered.storage.commons.RsaKeyAwareTest;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EncryptionKeyProviderTest extends RsaKeyAwareTest {
 
@@ -39,7 +40,7 @@ public class EncryptionKeyProviderTest extends RsaKeyAwareTest {
         final var key1 = ekp.createKey();
         final var key2 = ekp.createKey();
 
-        assertNotEquals(key1, key2);
+        assertThat(key1).isNotEqualTo(key2);
     }
 
     @Test
@@ -53,7 +54,7 @@ public class EncryptionKeyProviderTest extends RsaKeyAwareTest {
         final var encryptedKey = ekProvider.encryptKey(secretKey);
         final var restoredKey = ekProvider.decryptKey(encryptedKey);
 
-        assertEquals(secretKey, restoredKey);
+        assertThat(new SecretKeySpec(restoredKey, "AES")).isEqualTo(secretKey);
     }
 
 }

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3ClientWrapper.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3ClientWrapper.java
@@ -86,7 +86,8 @@ public class S3ClientWrapper {
         }
         final String metadataFileKey = getFileKey(remoteLogSegmentMetadata, METADATA_FILE_SUFFIX);
         final SecretKey encryptionKey = s3EncryptionKeyProvider.createOrRestoreEncryptionKey(metadataFileKey);
-        final CryptoIOProvider cryptoIOProvider = new CryptoIOProvider(encryptionKey, config.ioBufferSize());
+        final byte[] aad = s3EncryptionKeyProvider.createOrRestoreAAD(metadataFileKey);
+        final CryptoIOProvider cryptoIOProvider = new CryptoIOProvider(encryptionKey, aad, config.ioBufferSize());
         final ArrayList<InputStream> inputStreams = new ArrayList<>();
         for (int i = firstPart; i < lastPart - 1; i++) {
             final String key = logFileKey + "_" + i;
@@ -123,7 +124,8 @@ public class S3ClientWrapper {
         final String leaderEpochIndexFileKey = getFileKey(remoteLogSegmentMetadata, LEADER_EPOCH.name());
         final String metadataFileKey = getFileKey(remoteLogSegmentMetadata, METADATA_FILE_SUFFIX);
         final SecretKey encryptionKey = s3EncryptionKeyProvider.createOrRestoreEncryptionKey(metadataFileKey);
-        final CryptoIOProvider cryptoIOProvider = new CryptoIOProvider(encryptionKey, config.ioBufferSize());
+        final byte[] aad = s3EncryptionKeyProvider.createOrRestoreAAD(metadataFileKey);
+        final CryptoIOProvider cryptoIOProvider = new CryptoIOProvider(encryptionKey, aad, config.ioBufferSize());
         try {
             log.debug("Uploading log file: {}", logFileKey);
             uploadLogFile(cryptoIOProvider, logFileKey, logSegmentData.logSegment());
@@ -223,7 +225,8 @@ public class S3ClientWrapper {
                     new GetObjectRequest(config.s3BucketName(), objectSummaries.get(0).getKey());
             final String metadataFileKey = getFileKey(remoteLogSegmentMetadata, METADATA_FILE_SUFFIX);
             final SecretKey encryptionKey = s3EncryptionKeyProvider.createOrRestoreEncryptionKey(metadataFileKey);
-            final CryptoIOProvider cryptoIOProvider = new CryptoIOProvider(encryptionKey, config.ioBufferSize());
+            final byte[] aad = s3EncryptionKeyProvider.createOrRestoreAAD(metadataFileKey);
+            final CryptoIOProvider cryptoIOProvider = new CryptoIOProvider(encryptionKey, aad, config.ioBufferSize());
             final S3Object s3Object = s3Client.getObject(getObjectRequest);
             try {
                 return cryptoIOProvider.decryptAndDecompress(s3Object.getObjectContent());


### PR DESCRIPTION
Changed the encryption algorithm to AES/GCM with additional authenticated data.
To get additional authenticated data the 256 bit symmetric key utilized for encryption is replaced with 512 bit key where first 256 bit still utilized for encryption and last 256 bit as additional authenticated data.