### PR TITLE
Encryption metadata cache

### DIFF
--- a/s3/build.gradle
+++ b/s3/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation project(':commons')
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.14'
     implementation 'commons-io:commons-io:2.11.0'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.0.4'
     // Temporary. Will be later provided as transitive from kafka-storage-api
     runtimeOnly 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
     // Temporary. Will be later provided as transitive from kafka-clients.

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
@@ -60,22 +60,27 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
     private static final int IO_BUFFER_SIZE_DEFAULT = 8_192;
     private static final String IO_BUFFER_SIZE_DOC = "Buffer size for uploading";
 
-    public static final String S3_STORAGE_UPLOAD_PART_SIZE =
-            "s3.upload.part.size";
+    public static final String S3_STORAGE_UPLOAD_PART_SIZE = "s3.upload.part.size";
     private static final int S3_STORAGE_UPLOAD_PART_SIZE_DEFAULT = 524288;
     private static final String S3_STORAGE_UPLOAD_PART_SIZE_DOC = "S3 upload part size";
 
-    public static final String MULTIPART_UPLOAD_PART_SIZE =
-            "s3.multipart.upload.part.size";
+    public static final String MULTIPART_UPLOAD_PART_SIZE = "s3.multipart.upload.part.size";
     private static final int MULTIPART_UPLOAD_PART_SIZE_DEFAULT = 8_192;
     private static final String MULTIPART_UPLOAD_PART_SIZE_DOC = "S3 upload part size";
 
-    public static final String AWS_ACCESS_KEY_ID =
-            "s3.client.aws_access_key_id";
+    public static final String ENCRYPTION_METADATA_CACHE_SIZE = "s3.encryption.metadata.cache.size";
+    public static final long ENCRYPTION_METADATA_CACHE_SIZE_DEFAULT = 1000;
+    private static final String ENCRYPTION_METADATA_CACHE_SIZE_DOC = "Size of encryption metadata cache";
+
+    public static final String ENCRYPTION_METADATA_CACHE_RETENTION_MS = "s3.encryption.metadata.cache.retention.ms";
+    public static final long ENCRYPTION_METADATA_CACHE_RETENTION_MS_DEFAULT = 1_800_000;
+    private static final String ENCRYPTION_METADATA_CACHE_RETENTION_MS_DOC =
+            "Retention time for encryption metadata cache";
+
+    public static final String AWS_ACCESS_KEY_ID = "s3.client.aws_access_key_id";
     private static final String AWS_ACCESS_KEY_ID_DOC = "AWS Access Key ID";
 
-    public static final String AWS_SECRET_ACCESS_KEY =
-            "s3.client.aws_secret_access_key";
+    public static final String AWS_SECRET_ACCESS_KEY = "s3.client.aws_secret_access_key";
     private static final String AWS_SECRET_ACCESS_KEY_DOC = "AWS Secret Access Key";
 
     private static final ConfigDef CONFIG;
@@ -145,6 +150,24 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
             ConfigDef.Range.between(1024, Integer.MAX_VALUE),
             ConfigDef.Importance.HIGH,
             MULTIPART_UPLOAD_PART_SIZE_DOC
+        );
+
+        CONFIG.define(
+                ENCRYPTION_METADATA_CACHE_SIZE,
+                ConfigDef.Type.LONG,
+                ENCRYPTION_METADATA_CACHE_SIZE_DEFAULT,
+                ConfigDef.Range.between(0, Long.MAX_VALUE),
+                ConfigDef.Importance.LOW,
+                ENCRYPTION_METADATA_CACHE_SIZE_DOC
+        );
+
+        CONFIG.define(
+                ENCRYPTION_METADATA_CACHE_RETENTION_MS,
+                ConfigDef.Type.LONG,
+                ENCRYPTION_METADATA_CACHE_RETENTION_MS_DEFAULT,
+                ConfigDef.Range.between(0, Long.MAX_VALUE),
+                ConfigDef.Importance.LOW,
+                ENCRYPTION_METADATA_CACHE_RETENTION_MS_DOC
         );
 
         int awsGroupCounter = 0;
@@ -238,6 +261,14 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
 
     public int multiPartUploadPartSize() {
         return getInt(MULTIPART_UPLOAD_PART_SIZE);
+    }
+
+    public long encryptionMetadataCacheSize() {
+        return getLong(ENCRYPTION_METADATA_CACHE_SIZE);
+    }
+
+    public long encryptionMetadataCacheRetentionMs() {
+        return getLong(ENCRYPTION_METADATA_CACHE_RETENTION_MS);
     }
 
     public AWSCredentialsProvider awsCredentialsProvider() {

--- a/s3/src/test/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfigTest.java
+++ b/s3/src/test/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfigTest.java
@@ -51,6 +51,8 @@ class S3RemoteStorageManagerConfigTest {
         assertThat(config.ioBufferSize()).isEqualTo(8_192);
         assertThat(config.s3StorageUploadPartSize()).isEqualTo(1 << 19);
         assertThat(config.multiPartUploadPartSize()).isEqualTo(8_192);
+        assertThat(config.encryptionMetadataCacheSize()).isEqualTo(1000);
+        assertThat(config.encryptionMetadataCacheRetentionMs()).isEqualTo(1_800_000);
     }
 
     @Test
@@ -65,6 +67,8 @@ class S3RemoteStorageManagerConfigTest {
         properties.put("s3.io.buffer.size", "16384");
         properties.put("s3.upload.part.size", String.valueOf(1 << 10));
         properties.put("s3.multipart.upload.part.size", "16384");
+        properties.put("s3.encryption.metadata.cache.size", "2000");
+        properties.put("s3.encryption.metadata.cache.retention.ms", String.valueOf(3_600_000));
 
         final S3RemoteStorageManagerConfig config = new S3RemoteStorageManagerConfig(properties);
 
@@ -76,6 +80,8 @@ class S3RemoteStorageManagerConfigTest {
         assertThat(config.ioBufferSize()).isEqualTo(16_384);
         assertThat(config.s3StorageUploadPartSize()).isEqualTo(1 << 10);
         assertThat(config.multiPartUploadPartSize()).isEqualTo(16_384);
+        assertThat(config.encryptionMetadataCacheSize()).isEqualTo(2000);
+        assertThat(config.encryptionMetadataCacheRetentionMs()).isEqualTo(3_600_000);
     }
 
     @Test


### PR DESCRIPTION
Introducing a cache for encryption metadata(e.g. encryption key + aad per segment) to get rid of unnecessary repeating requests for the same data to AWS. 