### PR TITLE
Add S3 prefix support

### DIFF
--- a/s3/src/integration-test/java/io.aiven.kafka.tiered.storage.s3/S3RemoteStorageManagerTest.java
+++ b/s3/src/integration-test/java/io.aiven.kafka.tiered.storage.s3/S3RemoteStorageManagerTest.java
@@ -88,6 +88,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import static io.aiven.kafka.tiered.storage.s3.S3StorageUtils.filenamePrefixFromOffset;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -119,6 +120,7 @@ public class S3RemoteStorageManagerTest {
     private static AmazonS3 s3Client;
 
     private String bucket;
+    private String s3PathPrefix;
     private S3RemoteStorageManager remoteStorageManager;
 
     static {
@@ -148,10 +150,11 @@ public class S3RemoteStorageManagerTest {
 
         bucket = randomString(10).toLowerCase(Locale.ROOT);
         s3Client.createBucket(bucket);
+        s3PathPrefix = randomString(10).toLowerCase(Locale.ROOT);
         final AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(
                 Localstack.INSTANCE.getEndpointS3(), "us-east-1");
         remoteStorageManager = new S3RemoteStorageManager(endpointConfiguration);
-        remoteStorageManager.configure(basicProps(bucket));
+        remoteStorageManager.configure(basicProps(bucket, s3PathPrefix));
     }
 
     protected static void writePemFile(final Path path, final EncodedKeySpec encodedKeySpec) throws IOException {
@@ -213,13 +216,13 @@ public class S3RemoteStorageManagerTest {
                 s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_1",
                 s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_2",
                 s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_3",
-                s3Key(TP0, uuid1 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.OFFSET),
-                s3Key(TP0, uuid1 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.TIMESTAMP),
-                s3Key(TP0, uuid1 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
-                s3Key(TP0, uuid1 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.TRANSACTION),
                 s3Key(TP0, uuid1 + "-" + String.format("%020d", segment1.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.LEADER_EPOCH),
@@ -228,15 +231,15 @@ public class S3RemoteStorageManagerTest {
                 s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_1",
                 s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_2",
                 s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_3",
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.OFFSET),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.TIMESTAMP),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.TRANSACTION),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.LEADER_EPOCH),
                 s3Key(TP1, uuid2 + "-" + String.format("%020d", segment2.baseOffset()) + ".metadata.json")
         );
@@ -351,15 +354,15 @@ public class S3RemoteStorageManagerTest {
                 s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_1",
                 s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_2",
                 s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_3",
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.OFFSET),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.TIMESTAMP),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.TRANSACTION),
-                s3Key(TP1, uuid2 + "-" + S3StorageUtils.filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
                         + RemoteStorageManager.IndexType.LEADER_EPOCH),
                 s3Key(TP1, uuid2 + "-" + String.format("%020d", segment2.baseOffset()) + ".metadata.json")
         );
@@ -387,9 +390,10 @@ public class S3RemoteStorageManagerTest {
         }
     }
 
-    private static Map<String, String> basicProps(final String bucket) {
+    private static Map<String, String> basicProps(final String bucket, final String prefix) {
         final Map<String, String> props = new HashMap<>();
         props.put(S3RemoteStorageManagerConfig.S3_BUCKET_NAME_CONFIG, bucket);
+        props.put(S3RemoteStorageManagerConfig.S3_PREFIX, prefix);
         props.put(S3RemoteStorageManagerConfig.S3_CREDENTIALS_PROVIDER_CLASS_CONFIG,
                 AnonymousCredentialsProvider.class.getName());
         props.put(S3RemoteStorageManagerConfig.PUBLIC_KEY, publicKeyPem.toString());
@@ -441,9 +445,9 @@ public class S3RemoteStorageManagerTest {
         return objects.stream().map(S3ObjectSummary::getKey).collect(Collectors.toList());
     }
 
-    private static String s3Key(final TopicIdPartition topicIdPartition, final String name) {
-        return topicIdPartition.topicPartition().topic() + "-" + topicIdPartition.topicId() + "/"
-                + topicIdPartition.topicPartition().partition() + "/" + name;
+    private String s3Key(final TopicIdPartition topicIdPartition, final String name) {
+        return s3PathPrefix + "/" + topicIdPartition.topicPartition().topic() + "-" + topicIdPartition.topicId() + "/"
+            + topicIdPartition.topicPartition().partition() + "/" + name;
     }
 
     static class AnonymousCredentialsProvider implements AWSCredentialsProvider {

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
@@ -40,6 +40,10 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
     public static final String S3_BUCKET_NAME_CONFIG = "s3.bucket.name";
     private static final String S3_BUCKET_NAME_DOC = "The S3 Bucket.";
 
+    public static final String S3_PREFIX = "s3.prefix";
+
+    private static final String S3_PREFIX_DOC = "The S3 prefix";
+
     public static final String S3_REGION_CONFIG = "s3.region";
     private static final String S3_REGION_DEFAULT = Regions.DEFAULT_REGION.getName();
     private static final String S3_REGION_DOC = "The AWS region.";
@@ -96,6 +100,14 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
             new ConfigDef.NonEmptyString(),
             ConfigDef.Importance.HIGH,
             S3_BUCKET_NAME_DOC
+        );
+
+        CONFIG.define(
+            S3_PREFIX,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.MEDIUM,
+            S3_PREFIX_DOC
         );
 
         CONFIG.define(
@@ -236,6 +248,10 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
 
     public String s3BucketName() {
         return getString(S3_BUCKET_NAME_CONFIG);
+    }
+
+    public String s3Prefix() {
+        return getString(S3_PREFIX);
     }
 
     public Regions s3Region() {

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3StorageUtils.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3StorageUtils.java
@@ -25,10 +25,10 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 public class S3StorageUtils {
 
     public static String getFileKey(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
-                                    final String suffix) {
+                                     final String prefix, final String suffix) {
         final RemoteLogSegmentId remoteLogSegmentId = remoteLogSegmentMetadata.remoteLogSegmentId();
-        return fileNamePrefix(remoteLogSegmentId) + remoteLogSegmentId.id() + "-"
-                + filenamePrefixFromOffset(remoteLogSegmentMetadata.startOffset()) + "." + suffix;
+        return (prefix.isBlank() ? "" : prefix + "/") + fileNamePrefix(remoteLogSegmentId) + remoteLogSegmentId.id()
+            + "-" + filenamePrefixFromOffset(remoteLogSegmentMetadata.startOffset()) + "." + suffix;
     }
 
     private static String fileNamePrefix(final RemoteLogSegmentId remoteLogSegmentId) {

--- a/s3/src/test/java/io/aiven/kafka/tiered/storage/s3/S3StorageUtilsTest.java
+++ b/s3/src/test/java/io/aiven/kafka/tiered/storage/s3/S3StorageUtilsTest.java
@@ -39,22 +39,27 @@ class S3StorageUtilsTest {
         final TopicIdPartition topicIdPartition = new TopicIdPartition(Uuid.randomUuid(), topicPartition);
         final Uuid id = Uuid.randomUuid();
         final RemoteLogSegmentId remoteLogSegmentId = new RemoteLogSegmentId(topicIdPartition, id);
+        final String prefix = "path";
         final String suffix = "log";
 
         final RemoteLogSegmentMetadata metadata =
                 new RemoteLogSegmentMetadata(remoteLogSegmentId, 1, -1, -1, -1, 1L,
                         1, Collections.singletonMap(1, 100L));
 
-        assertThat(S3StorageUtils.getFileKey(metadata, suffix))
-                .isEqualTo(TOPIC + "-" + topicIdPartition.topicId() + "/"
+        assertThat(S3StorageUtils.getFileKey(metadata, "", suffix))
+            .isEqualTo(TOPIC + "-" + topicIdPartition.topicId() + "/"
+                + topicPartition.partition() + "/" + id + "-00000000000000000001." + suffix);
+
+        assertThat(S3StorageUtils.getFileKey(metadata, prefix, suffix))
+                .isEqualTo(prefix + "/" + TOPIC + "-" + topicIdPartition.topicId() + "/"
                         + topicPartition.partition() + "/" + id + "-00000000000000000001." + suffix);
 
         final RemoteLogSegmentMetadata metadata2 =
                 new RemoteLogSegmentMetadata(remoteLogSegmentId, Long.MAX_VALUE, -1, -1, -1, 1L,
                         1, Collections.singletonMap(1, 100L));
 
-        assertThat(S3StorageUtils.getFileKey(metadata2, suffix))
-                .isEqualTo(TOPIC + "-" + topicIdPartition.topicId() + "/"
-                        + topicPartition.partition() + "/" + id + "-09223372036854775807." + suffix);
+        assertThat(S3StorageUtils.getFileKey(metadata2, prefix, suffix))
+                .isEqualTo(prefix + "/" + TOPIC + "-" + topicIdPartition.topicId() + "/"
+                    + topicPartition.partition() + "/" + id + "-09223372036854775807." + suffix);
     }
 }


### PR DESCRIPTION
About this change - What it does
Adds new configuration parameter `s3.prefix` that will allow to prepend the path inside S3 bucket with some prefix. 

Resolves: #xxxxx
Why this way
