### PR TITLE
Use intermediate environment variable

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -24,8 +24,10 @@ jobs:
           ref: ${{ github.event.inputs.commit_hash }}
 
       - name: Check commit title and extract version
+        env:
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
         run: |
-          export commit_title=$(git log --pretty=format:%s -1 ${{ github.event.inputs.commit_hash }})
+          export commit_title=$(git log --pretty=format:%s -1 $COMMIT_HASH
           echo "Commit title: $commit_title"
           if [[ $commit_title =~ ^Release\ version\ [0-9]*\.[0-9]*\.[0-9]*$ ]]; then
             echo "Valid commit title"
@@ -50,11 +52,13 @@ jobs:
           echo zip_path=`realpath ./build/distributions/${zip_file}` >> $GITHUB_ENV
 
       - name: Create tag
+        env:
+          VERSION: ${{ env.version }}
         run: |
           git config --local user.name "GitHub Action"
           git config --local user.email "action@github.com"
-          git tag -a "v${{ env.version }}" -m "Release version ${{ env.version }}"
-          git push origin "v${{ env.version }}"
+          git tag -a "v$VERSION" -m "Release version $VERSION"
+          git push origin "v$VERSION"
 
       - name: Create release draft
         id: create_release

--- a/.github/workflows/release_pr_workflow.yml
+++ b/.github/workflows/release_pr_workflow.yml
@@ -16,15 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check versions
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          SNAPSHOT_VERSION: ${{ github.event.inputs.snapshot_version }}
         run: |
           echo "Checking release version..."
-          if echo ${{ github.event.inputs.release_version }} | grep --invert-match '^[0-9]\+\.[0-9]\+\.[0-9]\+$' > /dev/null; then
+          if echo $RELEASE_VERSION | grep --invert-match '^[0-9]\+\.[0-9]\+\.[0-9]\+$' > /dev/null; then
             echo "Release version is invalid"
             exit 1
           fi
 
           echo "Checking snapshot version..."
-          if echo ${{ github.event.inputs.snapshot_version }} | grep --invert-match '^[0-9]\+\.[0-9]\+\.[0-9]\+-SNAPSHOT$' > /dev/null; then
+          if echo $SNAPSHOT_VERSION | grep --invert-match '^[0-9]\+\.[0-9]\+\.[0-9]\+-SNAPSHOT$' > /dev/null; then
             echo "Snapshot version is invalid"
             exit 1
           fi
@@ -36,15 +39,18 @@ jobs:
           fetch-depth: 0
 
       - name: Create release commits
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
+          SNAPSHOT_VERSION: ${{ github.event.inputs.snapshot_version }}
         run: |
           git config --local user.name "GitHub Action"
           git config --local user.email "action@github.com"
-          sed -i -e "s/^version=.\+$/version=${{ github.event.inputs.release_version }}/g" gradle.properties
+          sed -i -e "s/^version=.\+$/version=$RELEASE_VERSION/g" gradle.properties
           git add gradle.properties
-          git commit -m "Release version ${{ github.event.inputs.release_version }}"
-          sed -i -e "s/^version=.\+$/version=${{ github.event.inputs.snapshot_version }}/g" gradle.properties
+          git commit -m "Release version $RELEASE_VERSION"
+          sed -i -e "s/^version=.\+$/version=$SNAPSHOT_VERSION/g" gradle.properties
           git add gradle.properties
-          git commit -m "Bump version to ${{ github.event.inputs.snapshot_version }}"
+          git commit -m "Bump version to $SNAPSHOT_VERSION"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
If you use environment variables directly inside a GitHub actions run block its possible to create a PR with a script that can extract the contents. Instead,  one should use intermediate environment variables, see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable.
