### PR TITLE
feat(metrics): add cache metrics to chunk cache disk

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCache.java
@@ -122,8 +122,9 @@ public abstract class ChunkCache<T> implements ChunkManager, Configurable {
         config.cacheSize().ifPresent(maximumWeight -> cacheBuilder.maximumWeight(maximumWeight).weigher(weigher()));
         config.cacheRetention().ifPresent(cacheBuilder::expireAfterAccess);
         return cacheBuilder.evictionListener(removalListener())
-                .scheduler(Scheduler.systemScheduler())
-                .executor(executor)
-                .buildAsync();
+            .scheduler(Scheduler.systemScheduler())
+            .executor(executor)
+            .recordStats(() -> new CaffeineStatsCounter("chunk-cache"))
+            .buildAsync();
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/CacheDiskBasedMetrics.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/CacheDiskBasedMetrics.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metrics;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.Value;
+import org.apache.kafka.common.utils.Time;
+
+import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CacheDiskBasedMetrics {
+    private static final Logger log = LoggerFactory.getLogger(DiskBasedChunkCache.class);
+
+    final Sensor pathSizeSensor;
+    final Sensor pathWrittenSensor;
+    final Sensor pathDeletedSensor;
+
+    AtomicLong pathSize;
+
+    public CacheDiskBasedMetrics(final String groupName, final Path directory) {
+        final JmxReporter reporter = new JmxReporter();
+
+        final org.apache.kafka.common.metrics.Metrics metrics = new org.apache.kafka.common.metrics.Metrics(
+            new MetricConfig(), List.of(reporter), Time.SYSTEM,
+            new KafkaMetricsContext("aiven.kafka.server.tieredstorage.cache.disk")
+        );
+
+        pathSizeSensor = new SensorProvider(metrics, "path-size")
+            .with(new MetricNameTemplate("path-size", groupName, ""), new Value())
+            .get();
+        final MetricNameTemplate pathWriteRate = new MetricNameTemplate("path-write-rate", groupName, "");
+        final MetricNameTemplate pathWriteTotal = new MetricNameTemplate("path-write-rate", groupName, "");
+        pathWrittenSensor = new SensorProvider(metrics, "path-write")
+            .with(pathWriteRate, new Rate())
+            .with(pathWriteTotal, new CumulativeSum())
+            .get();
+        final MetricNameTemplate pathDeleteRate = new MetricNameTemplate("path-delete-rate", groupName, "");
+        final MetricNameTemplate pathDeleteTotal = new MetricNameTemplate("path-delete-rate", groupName, "");
+        pathDeletedSensor = new SensorProvider(metrics, "path-delete")
+            .with(pathDeleteRate, new Rate())
+            .with(pathDeleteTotal, new CumulativeSum())
+            .get();
+
+        pathSize = new AtomicLong(FileUtils.sizeOfDirectory(directory.toFile()));
+    }
+
+    public void recordPathDeleted(final Path path) {
+        try {
+            final var size = Files.size(path);
+            final var dirSize = pathSize.addAndGet(-size);
+            pathDeletedSensor.record(size);
+            pathSizeSensor.record(dirSize);
+        } catch (final IOException e) {
+            log.error("Error when recording path [{}] size", path, e);
+        }
+    }
+
+    public void recordPathWritten(final Path path) {
+        try {
+            final var size = Files.size(path);
+            final var dirSize = pathSize.addAndGet(size);
+            pathWrittenSensor.record(size);
+            pathSizeSensor.record(dirSize);
+        } catch (final IOException e) {
+            log.error("Error when recording path [{}] size", path, e);
+        }
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheMetricsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import java.io.ByteArrayInputStream;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
+import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.assertj.core.data.Percentage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DiskBasedChunkCacheMetricsTest {
+    static final MBeanServer MBEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
+
+    static final long METRIC_TIME_WINDOW_SEC =
+        TimeUnit.SECONDS.convert(new MetricConfig().timeWindowMs(), TimeUnit.MILLISECONDS);
+
+    public static final Uuid SEGMENT_ID = Uuid.randomUuid();
+
+    static final int LOG_SEGMENT_BYTES = 10;
+    static final RemoteLogSegmentMetadata REMOTE_LOG_SEGMENT_METADATA =
+        new RemoteLogSegmentMetadata(
+            new RemoteLogSegmentId(
+                new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("topic", 0)),
+                SEGMENT_ID),
+            1, -1, -1, -1, 1L,
+            LOG_SEGMENT_BYTES, Collections.singletonMap(1, 100L));
+
+    @Mock
+    ChunkManager chunkManager;
+    @Mock
+    SegmentManifest segmentManifest;
+    @TempDir
+    Path baseCachePath;
+
+    DiskBasedChunkCache diskBasedChunkCache;
+
+    @BeforeEach
+    void setUp() {
+        diskBasedChunkCache = new DiskBasedChunkCache(chunkManager);
+        diskBasedChunkCache.configure(Map.of(
+            "retention.ms", "-1",
+            "size", "-1",
+            "path", baseCachePath.toString()
+        ));
+    }
+
+    @Test
+    void cacheChunks() throws Exception {
+        when(chunkManager.getChunk(any(), eq(segmentManifest), eq(0)))
+            .thenReturn(new ByteArrayInputStream("test".getBytes()));
+
+        diskBasedChunkCache.getChunk(REMOTE_LOG_SEGMENT_METADATA, segmentManifest, 0);
+        diskBasedChunkCache.getChunk(REMOTE_LOG_SEGMENT_METADATA, segmentManifest, 0);
+
+        final var segmentManifestCacheObjectName =
+            new ObjectName("aiven.kafka.server.tieredstorage.cache:type=chunk-cache");
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-hits-total"))
+            .isEqualTo(1.0);
+        AssertionsForClassTypes.assertThat(
+                (double) MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-hits-rate"))
+            .isCloseTo(1.0 / METRIC_TIME_WINDOW_SEC, Percentage.withPercentage(99));
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-misses-total"))
+            .isEqualTo(1.0);
+        AssertionsForClassTypes.assertThat(
+                (double) MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-misses-rate"))
+            .isCloseTo(1.0 / METRIC_TIME_WINDOW_SEC, Percentage.withPercentage(99));
+        AssertionsForClassTypes.assertThat(
+                (double) MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-load-success-time-total"))
+            .isGreaterThan(0);
+
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-load-success-total"))
+            .isEqualTo(1.0);
+        AssertionsForClassTypes.assertThat(
+                (double) MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-load-success-rate"))
+            .isCloseTo(1.0 / METRIC_TIME_WINDOW_SEC, Percentage.withPercentage(99));
+        AssertionsForClassTypes.assertThat(
+                (double) MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-load-failure-time-total"))
+            .isEqualTo(0);
+
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-load-failure-total"))
+            .isEqualTo(0.0);
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-load-failure-rate"))
+            .isEqualTo(0.0);
+
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-eviction-total"))
+            .isEqualTo(0.0);
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-eviction-rate"))
+            .isEqualTo(0.0);
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-eviction-weight-total"))
+            .isEqualTo(0.0);
+        AssertionsForClassTypes.assertThat(
+                MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-eviction-weight-rate"))
+            .isEqualTo(0.0);
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheTest.java
@@ -151,7 +151,7 @@ class DiskBasedChunkCacheTest {
     }
 
     @Test
-    void weighingTOoBigFiles() throws IOException {
+    void weighingTooBigFiles() throws IOException {
         final ByteArrayInputStream chunkStream = new ByteArrayInputStream(CHUNK_0);
         final ChunkKey chunkKey = new ChunkKey(SEGMENT_ID, 0);
 


### PR DESCRIPTION
This commits introduces a set of metrics for disk size, counting writes and delete rates and total.

Used by disk-based cache.

Depends on #323 
