### PR TITLE
feat(metrics:cache): Add metric for estimated cache size

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCache.java
@@ -130,10 +130,12 @@ public abstract class ChunkCache<T> implements ChunkManager, Configurable {
         final Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder();
         config.cacheSize().ifPresent(maximumWeight -> cacheBuilder.maximumWeight(maximumWeight).weigher(weigher()));
         config.cacheRetention().ifPresent(cacheBuilder::expireAfterAccess);
-        return cacheBuilder.evictionListener(removalListener())
+        final var cache = cacheBuilder.evictionListener(removalListener())
             .scheduler(Scheduler.systemScheduler())
             .executor(executor)
             .recordStats(() -> statsCounter)
             .buildAsync();
+        statsCounter.registerSizeMetric(cache.synchronous()::estimatedSize);
+        return cache;
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -183,10 +183,18 @@ class RemoteStorageManagerMetricsTest {
             }
         }
 
-        rsm.fetchLogSegment(REMOTE_LOG_SEGMENT_METADATA, 0);
+        // fetch related metrics
+        final var segmentManifestCacheObjectName =
+            new ObjectName("aiven.kafka.server.tieredstorage.cache:type=segment-manifest-cache");
+
         rsm.fetchLogSegment(REMOTE_LOG_SEGMENT_METADATA, 0);
 
-        // fetch related metrics
+        // check cache size increases after first miss
+        assertThat(MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-size-total"))
+            .isEqualTo(1.0);
+
+        rsm.fetchLogSegment(REMOTE_LOG_SEGMENT_METADATA, 0);
+
         assertThat(MBEAN_SERVER.getAttribute(metricName, "segment-fetch-rate"))
             .isEqualTo(2.0 / METRIC_TIME_WINDOW_SEC);
         assertThat(MBEAN_SERVER.getAttribute(metricName, "segment-fetch-total"))
@@ -197,8 +205,8 @@ class RemoteStorageManagerMetricsTest {
         assertThat(MBEAN_SERVER.getAttribute(metricName, "segment-fetch-requested-bytes-total"))
             .isEqualTo(20.0);
 
-        final var segmentManifestCacheObjectName =
-            new ObjectName("aiven.kafka.server.tieredstorage.cache:type=segment-manifest-cache");
+        assertThat(MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-size-total"))
+            .isEqualTo(1.0);
         assertThat(MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-hits-total"))
             .isEqualTo(1.0);
         assertThat(MBEAN_SERVER.getAttribute(segmentManifestCacheObjectName, "cache-misses-total"))

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheMetricsTest.java
@@ -89,12 +89,18 @@ class ChunkCacheMetricsTest {
         final var chunkCache = chunkCacheClass.getDeclaredConstructor(ChunkManager.class).newInstance(chunkManager);
         chunkCache.configure(config);
 
+        final var objectName = new ObjectName("aiven.kafka.server.tieredstorage.cache:type=chunk-cache");
+
         // When getting a existing chunk from cache
         chunkCache.getChunk(OBJECT_KEY_PATH, segmentManifest, 0);
+
+        // check cache size increases after first miss
+        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-size-total"))
+            .isEqualTo(1.0);
+
         chunkCache.getChunk(OBJECT_KEY_PATH, segmentManifest, 0);
 
         // Then the following metrics should be available
-        final var objectName = new ObjectName("aiven.kafka.server.tieredstorage.cache:type=chunk-cache");
         assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-hits-total"))
             .isEqualTo(1.0);
         assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-misses-total"))


### PR DESCRIPTION
Cache size is not included on default Caffeine stats. Piggybacking on counter to record updates to estimated size.

Reference: https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineStatsCounter.java
