### PR TITLE
Distribute dependency version lines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ subprojects {
 
     ext {
         junitVersion = "5.10.0"
+
         mockitoVersion = "5.4.0"
 
         // Don't bump this version without need, as this is the min supported version for the plugin.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,8 +21,11 @@ archivesBaseName = "core"
 
 ext {
     bouncyCastleVersion = "1.75"
+
     caffeineVersion = "3.1.7"
+
     zstdVersion = "1.5.5-5"
+
     jacksonVersion = "2.15.2"
 }
 


### PR DESCRIPTION
This allows to avoid constant rebasing when Dependabot kicks in.
