### PR TITLE
feat: Adopt segment custom metadata on write

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
@@ -18,10 +18,13 @@ package io.aiven.kafka.tieredstorage.config;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -30,6 +33,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Utils;
 
+import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
@@ -81,6 +85,11 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
 
     public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
     private static final String METRICS_RECORDING_LEVEL_DOC = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC;
+
+    private static final String CUSTOM_METADATA_FIELDS_INCLUDE_CONFIG = "custom.metadata.fields.include";
+    private static final String CUSTOM_METADATA_FIELDS_INCLUDE_DOC = "Custom Metadata to be stored along "
+        + "Remote Log Segment metadata on Remote Log Metadata Manager back-end. "
+        + "Allowed values: " + Arrays.toString(SegmentCustomMetadataField.names());
 
     private static final ConfigDef CONFIG;
 
@@ -179,6 +188,13 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
                 Sensor.RecordingLevel.TRACE.toString()),
             ConfigDef.Importance.LOW,
             METRICS_RECORDING_LEVEL_DOC);
+
+        CONFIG.define(CUSTOM_METADATA_FIELDS_INCLUDE_CONFIG,
+            ConfigDef.Type.LIST,
+            "",
+            ConfigDef.ValidList.in(SegmentCustomMetadataField.names()),
+            ConfigDef.Importance.LOW,
+            CUSTOM_METADATA_FIELDS_INCLUDE_DOC);
     }
 
     /**
@@ -355,5 +371,11 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
             result.put(keyPairId, keyPair);
         }
         return result;
+    }
+
+    public Set<SegmentCustomMetadataField> customMetadataKeysIncluded() {
+        return getList(CUSTOM_METADATA_FIELDS_INCLUDE_CONFIG).stream()
+            .map(SegmentCustomMetadataField::valueOf)
+            .collect(Collectors.toSet());
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
@@ -82,7 +82,6 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
     public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
     private static final String METRICS_RECORDING_LEVEL_DOC = CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC;
 
-
     private static final ConfigDef CONFIG;
 
     static {
@@ -157,27 +156,29 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
             ENCRYPTION_DOC
         );
 
-        CONFIG
-            .define(METRICS_SAMPLE_WINDOW_MS_CONFIG,
-                ConfigDef.Type.LONG,
-                30000,
-                atLeast(1),
-                ConfigDef.Importance.LOW,
-                METRICS_SAMPLE_WINDOW_MS_DOC);
-        CONFIG.define(METRICS_NUM_SAMPLES_CONFIG,
-                ConfigDef.Type.INT,
-                2,
-                atLeast(1),
-                ConfigDef.Importance.LOW,
-                METRICS_NUM_SAMPLES_DOC);
-        CONFIG.define(METRICS_RECORDING_LEVEL_CONFIG,
-                ConfigDef.Type.STRING,
-                Sensor.RecordingLevel.INFO.toString(),
-                in(Sensor.RecordingLevel.INFO.toString(),
-                    Sensor.RecordingLevel.DEBUG.toString(),
-                    Sensor.RecordingLevel.TRACE.toString()),
-                ConfigDef.Importance.LOW,
-                METRICS_RECORDING_LEVEL_DOC);
+        CONFIG.define(
+            METRICS_SAMPLE_WINDOW_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            30000,
+            atLeast(1),
+            ConfigDef.Importance.LOW,
+            METRICS_SAMPLE_WINDOW_MS_DOC);
+        CONFIG.define(
+            METRICS_NUM_SAMPLES_CONFIG,
+            ConfigDef.Type.INT,
+            2,
+            atLeast(1),
+            ConfigDef.Importance.LOW,
+            METRICS_NUM_SAMPLES_DOC);
+        CONFIG.define(
+            METRICS_RECORDING_LEVEL_CONFIG,
+            ConfigDef.Type.STRING,
+            Sensor.RecordingLevel.INFO.toString(),
+            in(Sensor.RecordingLevel.INFO.toString(),
+                Sensor.RecordingLevel.DEBUG.toString(),
+                Sensor.RecordingLevel.TRACE.toString()),
+            ConfigDef.Importance.LOW,
+            METRICS_RECORDING_LEVEL_DOC);
     }
 
     /**

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataBuilder.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metadata;
+
+import java.util.EnumMap;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
+import io.aiven.kafka.tieredstorage.ObjectKey;
+
+public class SegmentCustomMetadataBuilder {
+    final ObjectKey objectKey;
+    final RemoteLogSegmentMetadata segmentMetadata;
+    final EnumMap<ObjectKey.Suffix, Long> uploadResults;
+
+    final Set<SegmentCustomMetadataField> fields;
+
+    public SegmentCustomMetadataBuilder(final Set<SegmentCustomMetadataField> fields,
+                                        final ObjectKey objectKey,
+                                        final RemoteLogSegmentMetadata segmentMetadata) {
+        this.fields = fields;
+        this.objectKey = objectKey;
+        this.segmentMetadata = segmentMetadata;
+        this.uploadResults = new EnumMap<>(ObjectKey.Suffix.class);
+    }
+
+    public SegmentCustomMetadataBuilder addUploadResult(final ObjectKey.Suffix suffix,
+                                                        final long bytes) {
+        if (uploadResults.containsKey(suffix)) {
+            throw new IllegalArgumentException("Upload results for suffix " + suffix + " already added");
+        }
+        uploadResults.put(suffix, bytes);
+        return this;
+    }
+
+    public long totalSize() {
+        return uploadResults.values().stream().mapToLong(value -> value).sum();
+    }
+
+    /**
+     * {@code NavigableMap} is required by {@link org.apache.kafka.common.protocol.types.TaggedFields},
+     * therefore is enforced on this API.
+     */
+    public NavigableMap<Integer, Object> build() {
+        final TreeMap<Integer, Object> taggedFields = new TreeMap<>();
+        fields.forEach(field -> taggedFields.put(field.ordinal(), field.valueProvider.apply(this)));
+        return taggedFields;
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataField.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataField.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metadata;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Field.TaggedFieldsSection;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Type;
+
+import io.aiven.kafka.tieredstorage.ObjectKey;
+
+// index define values on custom metadata fields and cannot be changed without breaking compatibility.
+public enum SegmentCustomMetadataField {
+    REMOTE_SIZE(0, new Field("remote_size", Type.VARLONG), SegmentCustomMetadataBuilder::totalSize),
+    OBJECT_PREFIX(1, new Field("object_prefix", Type.COMPACT_STRING), b -> b.objectKey.prefix()),
+    OBJECT_KEY(2, new Field("object_key", Type.COMPACT_STRING), b -> ObjectKey.mainPath(b.segmentMetadata));
+
+    static final TaggedFieldsSection FIELDS_SECTION = TaggedFieldsSection.of(
+        REMOTE_SIZE.index, REMOTE_SIZE.field,
+        OBJECT_PREFIX.index, OBJECT_PREFIX.field,
+        OBJECT_KEY.index, OBJECT_KEY.field
+    );
+    public static final Schema CUSTOM_METADATA_SCHEMA = new Schema(FIELDS_SECTION);
+    public static final String TAGGED_FIELD_NAME = FIELDS_SECTION.name;
+
+    final int index;
+    final Field field;
+    final Function<SegmentCustomMetadataBuilder, Object> valueProvider;
+
+    SegmentCustomMetadataField(final int index,
+                               final Field field,
+                               final Function<SegmentCustomMetadataBuilder, Object> valueProvider) {
+        this.index = index;
+        this.field = field;
+        this.valueProvider = valueProvider;
+    }
+
+    public static String[] names() {
+        return Arrays.stream(SegmentCustomMetadataField.values())
+            .map(SegmentCustomMetadataField::name)
+            .toArray(String[]::new);
+    }
+
+    public int index() {
+        return index;
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataSerde.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataSerde.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metadata;
+
+import java.nio.ByteBuffer;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import org.apache.kafka.common.protocol.types.Struct;
+
+import static io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField.CUSTOM_METADATA_SCHEMA;
+import static io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField.TAGGED_FIELD_NAME;
+
+/**
+ * Serialize and deserialize {@code NavigableMap} based on fields defined by {@code SegmentCustomMetadataField}.
+ *
+ * <p>{@code NavigableMap} is required by {@link org.apache.kafka.common.protocol.types.TaggedFields},
+ * therefore is enforced on this API.
+ */
+public class SegmentCustomMetadataSerde {
+
+    public byte[] serialize(final NavigableMap<Integer, Object> data) {
+        if (data.isEmpty()) {
+            return new byte[]{};
+        }
+
+        final var struct = new Struct(CUSTOM_METADATA_SCHEMA);
+        struct.set(TAGGED_FIELD_NAME, data);
+
+        final var buf = ByteBuffer.allocate(struct.sizeOf());
+        struct.writeTo(buf);
+        return buf.array();
+    }
+
+    public NavigableMap<Integer, Object> deserialize(final byte[] data) {
+        if (data == null || data.length == 0) {
+            return new TreeMap<>();
+        }
+
+        final var buf = ByteBuffer.wrap(data);
+        final var struct = CUSTOM_METADATA_SCHEMA.read(buf);
+
+        @SuppressWarnings("unchecked") final var fields =
+            (NavigableMap<Integer, Object>) struct.get(TAGGED_FIELD_NAME);
+        return fields;
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataBuilderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataBuilderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metadata;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
+import io.aiven.kafka.tieredstorage.ObjectKey;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+class SegmentCustomMetadataBuilderTest {
+    static final Uuid TOPIC_ID = Uuid.randomUuid();
+    static final Uuid SEGMENT_ID = Uuid.randomUuid();
+    static final RemoteLogSegmentMetadata REMOTE_LOG_SEGMENT_METADATA =
+        new RemoteLogSegmentMetadata(
+            new RemoteLogSegmentId(
+                new TopicIdPartition(TOPIC_ID, new TopicPartition("topic", 0)),
+                SEGMENT_ID),
+            1, 100, -1, -1, 1L,
+            100, Collections.singletonMap(1, 100L));
+    static final ObjectKey OBJECT_KEY = new ObjectKey("p1");
+
+    @Test
+    void shouldBuildEmptyMap() {
+        final var b = new SegmentCustomMetadataBuilder(Set.of(), OBJECT_KEY, REMOTE_LOG_SEGMENT_METADATA);
+        assertThat(b.build()).isEmpty();
+
+        // even when upload results are added
+        b.addUploadResult(ObjectKey.Suffix.MANIFEST, 10L);
+        assertThat(b.build()).isEmpty();
+    }
+
+    @Test
+    void shouldFailWhenAddingExistingSuffixUploadResult() {
+        final var b = new SegmentCustomMetadataBuilder(Set.of(), OBJECT_KEY, REMOTE_LOG_SEGMENT_METADATA);
+
+        b.addUploadResult(ObjectKey.Suffix.MANIFEST, 10L);
+        assertThatThrownBy(() -> b.addUploadResult(ObjectKey.Suffix.MANIFEST, 20L))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Upload results for suffix MANIFEST already added");
+    }
+
+    @Test
+    void shouldIncludeTotalSize() {
+        final var field = SegmentCustomMetadataField.REMOTE_SIZE;
+        final var b = new SegmentCustomMetadataBuilder(Set.of(field), OBJECT_KEY, REMOTE_LOG_SEGMENT_METADATA);
+        var fields = b.build();
+        assertThat(fields)
+            .containsExactly(entry(field.index, 0L)); // i.e. no upload results
+
+        // but, when existing upload results
+        b
+            .addUploadResult(ObjectKey.Suffix.LOG, 40L)
+            .addUploadResult(ObjectKey.Suffix.MANIFEST, 2L);
+        fields = b.build();
+        assertThat(fields)
+            .containsExactly(entry(field.index, 42L)); // i.e. sum
+    }
+
+    @Test
+    void shouldIncludeObjectPrefix() {
+        final var field = SegmentCustomMetadataField.OBJECT_PREFIX;
+        final var b = new SegmentCustomMetadataBuilder(Set.of(field), OBJECT_KEY, REMOTE_LOG_SEGMENT_METADATA);
+        final var fields = b.build();
+        assertThat(fields)
+            .containsExactly(entry(field.index, "p1"));
+    }
+
+    @Test
+    void shouldIncludeObjectKey() {
+        final var field = SegmentCustomMetadataField.OBJECT_KEY;
+        final var b = new SegmentCustomMetadataBuilder(Set.of(field), OBJECT_KEY, REMOTE_LOG_SEGMENT_METADATA);
+        final var fields = b.build();
+        assertThat(fields)
+            .containsExactly(entry(field.index, "topic-" + TOPIC_ID + "/0/00000000000000000001-" + SEGMENT_ID));
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataSerdeTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataSerdeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metadata;
+
+import java.util.TreeMap;
+
+import org.apache.kafka.common.protocol.types.SchemaException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SegmentCustomMetadataSerdeTest {
+    final SegmentCustomMetadataSerde serde = new SegmentCustomMetadataSerde();
+
+    @Test
+    void shouldSerDeEmptyFields() {
+        final var bytes = serde.serialize(new TreeMap<>());
+        assertThat(bytes).isEqualTo(new byte[] {});
+        final var fields = serde.deserialize(bytes);
+        assertThat(fields).isEmpty();
+    }
+
+    @Test
+    void shouldSerDeSomeFields() {
+        final var input = new TreeMap<Integer, Object>();
+        input.put(0, 100L); // remote_size
+        input.put(2, "foo"); // object_key
+
+        final var bytes = serde.serialize(input);
+        assertThat(bytes).hasSize(11); // calculated on the first run
+        final var fields = serde.deserialize(bytes);
+        assertThat(fields).hasSize(2)
+            .containsEntry(0, 100L)
+            .containsEntry(2, "foo");
+    }
+
+    @Test
+    void shouldFailWhenWrongType() {
+        final var input = new TreeMap<Integer, Object>();
+        input.put(0, "foo"); // remote_size with wrong type
+
+        assertThatThrownBy(() -> serde.serialize(input))
+            .isInstanceOf(SchemaException.class);
+    }
+
+    @Test
+    void shouldFailWhenUnknownLocation() {
+        final var input = new TreeMap<Integer, Object>();
+        input.put(SegmentCustomMetadataField.values().length + 1, "foo"); // unknown location
+
+        assertThatThrownBy(() -> serde.serialize(input))
+            .isInstanceOf(SchemaException.class);
+    }
+}


### PR DESCRIPTION
Segment custom metadata, introduced in [KIP-917], will be adopted by plugin to collect additional processing metadata for further usage.

Initial fields:
- total bytes: Including manifest and indexes sizes to log segment size.
- object key and prefix: for further usage on read path. 

Depends on #354

To do:

- [x] Using trunk snapshot to get access to latest APIs.
- [x] Add custom fields to configuration.
- [x] Test RSM with custom metadata.

[KIP-917]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-917%3A+Additional+custom+metadata+for+remote+log+segment
