### PR TITLE
refactor: Pass key path instead of log metadata + object key

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkKey.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkKey.java
@@ -16,20 +16,17 @@
 
 package io.aiven.kafka.tieredstorage.chunkmanager;
 
+import java.nio.file.Path;
 import java.util.Objects;
 
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
-
 public class ChunkKey {
-    public final Uuid uuid;
+    public final String segmentFileName;
     public final int chunkId;
 
-    /**
-     * @param uuid segment UUID, see {@link RemoteLogSegmentId#id()}.
-     */
-    public ChunkKey(final Uuid uuid, final int chunkId) {
-        this.uuid = Objects.requireNonNull(uuid, "uuid cannot be null");
+    public ChunkKey(final String objectKeyPath, final int chunkId) {
+        Objects.requireNonNull(objectKeyPath, "objectKeyPath cannot be null");
+        // get last part of segment path + chunk id, as it's used for creating file names
+        this.segmentFileName = Path.of(objectKeyPath).getFileName().toString();
         this.chunkId = chunkId;
     }
 
@@ -47,12 +44,12 @@ public class ChunkKey {
         if (chunkId != chunkKey.chunkId) {
             return false;
         }
-        return Objects.equals(uuid, chunkKey.uuid);
+        return Objects.equals(segmentFileName, chunkKey.segmentFileName);
     }
 
     @Override
     public int hashCode() {
-        int result = uuid != null ? uuid.hashCode() : 0;
+        int result = segmentFileName.hashCode();
         result = 31 * result + chunkId;
         return result;
     }
@@ -60,8 +57,12 @@ public class ChunkKey {
     @Override
     public String toString() {
         return "ChunkKey("
-            + "uuid=" + uuid
+            + "segmentFileName=" + segmentFileName
             + ", chunkId=" + chunkId
             + ")";
+    }
+
+    public String path() {
+        return segmentFileName + "-" + chunkId;
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManager.java
@@ -19,14 +19,12 @@ package io.aiven.kafka.tieredstorage.chunkmanager;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
-
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
 
 public interface ChunkManager {
 
-    InputStream getChunk(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+    InputStream getChunk(final String objectKeyPath,
                          final SegmentManifest manifest,
                          final int chunkId) throws StorageBackendException, IOException;
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactory.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactory.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import org.apache.kafka.common.Configurable;
 
-import io.aiven.kafka.tieredstorage.ObjectKey;
 import io.aiven.kafka.tieredstorage.chunkmanager.cache.ChunkCache;
 import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
 import io.aiven.kafka.tieredstorage.storage.ObjectFetcher;
@@ -34,19 +33,14 @@ public class ChunkManagerFactory implements Configurable {
     }
 
     public ChunkManager initChunkManager(final ObjectFetcher fileFetcher,
-                                         final ObjectKey objectKey,
                                          final AesEncryptionProvider aesEncryptionProvider) {
-        final DefaultChunkManager defaultChunkManager = new DefaultChunkManager(
-                fileFetcher,
-                objectKey,
-                aesEncryptionProvider
-        );
+        final DefaultChunkManager defaultChunkManager = new DefaultChunkManager(fileFetcher, aesEncryptionProvider);
         if (config.cacheClass() != null) {
             try {
                 final ChunkCache<?> chunkCache = config
-                        .cacheClass()
-                        .getDeclaredConstructor(ChunkManager.class)
-                        .newInstance(defaultChunkManager);
+                    .cacheClass()
+                    .getDeclaredConstructor(ChunkManager.class)
+                    .newInstance(defaultChunkManager);
                 chunkCache.configure(config.originalsWithPrefix(ChunkManagerFactoryConfig.CHUNK_CACHE_PREFIX));
                 return chunkCache;
             } catch (final ReflectiveOperationException e) {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCache.java
@@ -87,9 +87,14 @@ public class DiskBasedChunkCache extends ChunkCache<Path> {
     public RemovalListener<ChunkKey, Path> removalListener() {
         return (key, path, cause) -> {
             try {
-                Files.delete(path);
-                log.debug("Deleted cached file for key {} with path {} from cache directory."
+                if (path != null) {
+                    Files.delete(path);
+                    log.debug("Deleted cached file for key {} with path {} from cache directory."
                         + " The reason of the deletion is {}", key, path, cause);
+                } else {
+                    log.warn("Path not present when trying to delete cached file for key {} from cache directory."
+                        + " The reason of the deletion is {}", key, cause);
+                }
             } catch (final IOException e) {
                 log.error("Failed to delete cached file for key {} with path {} from cache directory."
                               + " The reason of the deletion is {}", key, path, cause, e);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCache.java
@@ -59,12 +59,11 @@ public class DiskBasedChunkCache extends ChunkCache<Path> {
      */
     @Override
     public Path cacheChunk(final ChunkKey chunkKey, final InputStream chunk) throws IOException {
-        final Path tempChunkPath = config.tempCachePath()
-                .resolve(chunkKey.uuid + "-" + chunkKey.chunkId);
+        final var chunkKeyPath = chunkKey.path();
+        final Path tempChunkPath = config.tempCachePath().resolve(chunkKeyPath);
         final Path tempCached = writeToDisk(chunk, tempChunkPath);
         log.debug("Chunk file has been stored to temporary caching directory {}", tempCached);
-        final Path cachedChunkPath = config.cachePath()
-                .resolve(chunkKey.uuid + "-" + chunkKey.chunkId);
+        final Path cachedChunkPath = config.cachePath().resolve(chunkKeyPath);
         try {
             final Path newPath = Files.move(tempCached, cachedChunkPath, ATOMIC_MOVE);
             log.debug("Chunk file has been moved to cache directory {}", newPath);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkKeyTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkKeyTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ChunkKeyTest {
-    static final Uuid UUID_1 = Uuid.randomUuid();
-    static final Uuid UUID_2 = Uuid.randomUuid();
+    static final String UUID_1 = "topic/" + Uuid.randomUuid();
+    static final String UUID_2 = "topic/" + Uuid.randomUuid();
 
     @Test
     void identical() {
@@ -51,5 +51,15 @@ class ChunkKeyTest {
         assertThat(ck1).isNotEqualTo(ck2);
         assertThat(ck2).isNotEqualTo(ck1);
         assertThat(ck1).doesNotHaveSameHashCodeAs(ck2);
+    }
+
+    @Test
+    void singlePath() {
+        assertThat(new ChunkKey("test", 0).path()).isEqualTo("test-0");
+    }
+
+    @Test
+    void pathWitDir() {
+        assertThat(new ChunkKey("parent/test", 0).path()).isEqualTo("test-0");
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactoryTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactoryTest.java
@@ -53,7 +53,7 @@ class ChunkManagerFactoryTest {
     @Test
     void defaultChunkManager() {
         chunkManagerFactory.configure(Map.of());
-        final ChunkManager chunkManager = chunkManagerFactory.initChunkManager(null, null, null);
+        final ChunkManager chunkManager = chunkManagerFactory.initChunkManager(null, null);
         assertThat(chunkManager).isInstanceOf(DefaultChunkManager.class);
     }
 
@@ -71,6 +71,7 @@ class ChunkManagerFactoryTest {
             final ChunkManager chunkManager = chunkManagerFactory.initChunkManager(null,
                 null,
                 null);
+            final ChunkManager chunkManager = chunkManagerFactory.initChunkManager(null, null);
             assertThat(chunkManager).isInstanceOf(cls);
             verify((ChunkCache<?>) chunkManager).configure(Map.of(
                 "class", cls,
@@ -87,7 +88,7 @@ class ChunkManagerFactoryTest {
             (cachingChunkManager, context) -> {
                 throw new InvocationTargetException(null);
             })) {
-            assertThatThrownBy(() -> chunkManagerFactory.initChunkManager(null, null, null))
+            assertThatThrownBy(() -> chunkManagerFactory.initChunkManager(null, null))
                 .isInstanceOf(RuntimeException.class)
                 .hasCauseInstanceOf(ReflectiveOperationException.class);
         }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactoryTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactoryTest.java
@@ -67,10 +67,7 @@ class ChunkManagerFactoryTest {
                 "other.config.x", 10
             )
         );
-        try (final MockedConstruction<?> mock = mockConstruction(cls)) {
-            final ChunkManager chunkManager = chunkManagerFactory.initChunkManager(null,
-                null,
-                null);
+        try (final MockedConstruction<?> ignored = mockConstruction(cls)) {
             final ChunkManager chunkManager = chunkManagerFactory.initChunkManager(null, null);
             assertThat(chunkManager).isInstanceOf(cls);
             verify((ChunkCache<?>) chunkManager).configure(Map.of(
@@ -84,7 +81,7 @@ class ChunkManagerFactoryTest {
     @Test
     void failedInitialization() {
         chunkManagerFactory.configure(Map.of("chunk.cache.class", InMemoryChunkCache.class));
-        try (final MockedConstruction<?> mock = mockConstruction(InMemoryChunkCache.class,
+        try (final MockedConstruction<?> ignored = mockConstruction(InMemoryChunkCache.class,
             (cachingChunkManager, context) -> {
                 throw new InvocationTargetException(null);
             })) {

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheMetricsTest.java
@@ -22,15 +22,8 @@ import javax.management.ObjectName;
 import java.io.ByteArrayInputStream;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import org.apache.kafka.common.TopicIdPartition;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
-import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
@@ -56,16 +49,7 @@ import static org.mockito.Mockito.when;
 class ChunkCacheMetricsTest {
     static final MBeanServer MBEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
 
-    public static final Uuid SEGMENT_ID = Uuid.randomUuid();
-
-    static final int LOG_SEGMENT_BYTES = 10;
-    static final RemoteLogSegmentMetadata REMOTE_LOG_SEGMENT_METADATA =
-        new RemoteLogSegmentMetadata(
-            new RemoteLogSegmentId(
-                new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("topic", 0)),
-                SEGMENT_ID),
-            1, -1, -1, -1, 1L,
-            LOG_SEGMENT_BYTES, Collections.singletonMap(1, 100L));
+    public static final String OBJECT_KEY_PATH = "topic/segment";
 
     @TempDir
     static Path baseCachePath;
@@ -106,8 +90,8 @@ class ChunkCacheMetricsTest {
         chunkCache.configure(config);
 
         // When getting a existing chunk from cache
-        chunkCache.getChunk(REMOTE_LOG_SEGMENT_METADATA, segmentManifest, 0);
-        chunkCache.getChunk(REMOTE_LOG_SEGMENT_METADATA, segmentManifest, 0);
+        chunkCache.getChunk(OBJECT_KEY_PATH, segmentManifest, 0);
+        chunkCache.getChunk(OBJECT_KEY_PATH, segmentManifest, 0);
 
         // Then the following metrics should be available
         final var objectName = new ObjectName("aiven.kafka.server.tieredstorage.cache:type=chunk-cache");

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheTest.java
@@ -22,8 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import org.apache.kafka.common.Uuid;
-
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
 
@@ -52,7 +50,7 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class DiskBasedChunkCacheTest {
-    public static final Uuid SEGMENT_ID = Uuid.randomUuid();
+    public static final String SEGMENT_ID = "topic/segment";
     private static final byte[] CHUNK_0 = "0123456789".getBytes();
     private static final byte[] CHUNK_1 = "1011121314".getBytes();
     private static final String TEST_EXCEPTION_MESSAGE = "test_message";

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
@@ -59,7 +59,7 @@ class FetchChunkEnumerationTest {
         // Then
         assertThatThrownBy(
             () -> new FetchChunkEnumeration(chunkManager, SEGMENT_KEY_PATH, manifest, BytesRange.of(from, to)))
-            .hasMessage("Invalid start position " + from + " in segment topic/segment");
+            .hasMessage("Invalid start position " + from + " in segment path topic/segment");
     }
 
     //   - End position within index


### PR DESCRIPTION
To reduce coupling, and define path on RSM instead of down the chunk manager. A nice side effect is that dependencies on metadata get reduced to only RSM (where it belongs). Object Key also ends up being used only by the RSM

This changes are required by following PRs, as path to a segment can be based on the custom metadata (available on RSM). To avoid having to send another field all the way down to transformers, etc. with this change, all can be solved at the RSM level (as it's solved for indexes and manifest file.