### PR TITLE
fix: handle jackson dependency conflict between core module and s3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,8 @@ subprojects {
         assertJVersion = "3.24.2"
 
         apacheCommonsIOVersion = "2.13.0"
+
+        jacksonVersion = "2.15.2"
     }
 
     dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,22 +28,20 @@ ext {
 
     zstdVersion = "1.5.5-5"
 
-    jacksonVersion = "2.15.2"
-
     awaitilityVersion = "4.2.0"
 }
 
 dependencies {
     implementation project(":storage:core")
 
+    // These dependencies are load via specific classloader, only check collisions with inner dependencies (e.g. storage)
+
     implementation "org.bouncycastle:bcprov-jdk18on:$bouncyCastleVersion"
 
-    // Should be provided at the run time.
-    compileOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
 
-    // Should be provided at the run time.
-    compileOnly "com.github.luben:zstd-jni:$zstdVersion"
+    implementation "com.github.luben:zstd-jni:$zstdVersion"
 
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -228,7 +228,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             }
             final ByteBufferInputStream leaderEpoch = new ByteBufferInputStream(logSegmentData.leaderEpochIndex());
             uploadIndexFile(remoteLogSegmentMetadata, leaderEpoch, LEADER_EPOCH, encryptionMetadata);
-        } catch (final StorageBackendException | IOException e) {
+        } catch (final Exception e) {
             metrics.recordSegmentCopyError(remoteLogSegmentMetadata.remoteLogSegmentId()
                 .topicIdPartition().topicPartition());
             throw new RemoteStorageException(e);
@@ -355,7 +355,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
             return new FetchChunkEnumeration(chunkManager, segmentKey, segmentManifest, range)
                 .toInputStream();
-        } catch (final StorageBackendException | IOException e) {
+        } catch (final Exception e) {
             throw new RemoteStorageException(e);
         }
     }
@@ -388,7 +388,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             }
             final DetransformFinisher detransformFinisher = new DetransformFinisher(detransformEnum);
             return detransformFinisher.toInputStream();
-        } catch (final StorageBackendException | IOException e) {
+        } catch (final Exception e) {
             // TODO: should be aligned with upstream implementation
             if (indexType == TRANSACTION) {
                 return null;
@@ -415,7 +415,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 final String key = objectKey.key(remoteLogSegmentMetadata, suffix);
                 deleter.delete(key);
             }
-        } catch (final StorageBackendException e) {
+        } catch (final Exception e) {
             metrics.recordSegmentDeleteError(remoteLogSegmentMetadata.remoteLogSegmentId()
                 .topicIdPartition().topicPartition());
             throw new RemoteStorageException(e);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -272,7 +272,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 bytes
             );
 
-            log.trace("Uploaded segment log for {}, size: {}", remoteLogSegmentMetadata, bytes);
+            log.debug("Uploaded segment log for {}, size: {}", remoteLogSegmentMetadata, bytes);
         }
     }
 
@@ -301,7 +301,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 bytes
             );
 
-            log.trace("Uploaded index file {} for {}, size: {}", indexType, remoteLogSegmentMetadata, bytes);
+            log.debug("Uploaded index file {} for {}, size: {}", indexType, remoteLogSegmentMetadata, bytes);
         }
     }
 
@@ -319,7 +319,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 bytes
             );
 
-            log.trace("Uploaded segment manifest for {}, size: {}", remoteLogSegmentMetadata, bytes);
+            log.debug("Uploaded segment manifest for {}, size: {}", remoteLogSegmentMetadata, bytes);
         }
     }
 
@@ -343,7 +343,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 Math.min(endPosition, remoteLogSegmentMetadata.segmentSizeInBytes() - 1)
             );
 
-            log.debug("Fetching log segment {} with range: {}", remoteLogSegmentMetadata, range);
+            log.trace("Fetching log segment {} with range: {}", remoteLogSegmentMetadata, range);
 
             metrics.recordSegmentFetch(
                 remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
@@ -370,7 +370,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
     public InputStream fetchIndex(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
                                   final IndexType indexType) throws RemoteStorageException {
         try {
-            log.debug("Fetching index {} for {}", indexType, remoteLogSegmentMetadata);
+            log.trace("Fetching index {} for {}", indexType, remoteLogSegmentMetadata);
 
             final var segmentManifest = fetchSegmentManifest(remoteLogSegmentMetadata);
 

--- a/storage/s3/build.gradle
+++ b/storage/s3/build.gradle
@@ -27,7 +27,14 @@ ext {
 dependencies {
     implementation project(":storage:core")
 
-    implementation "com.amazonaws:aws-java-sdk-s3:$awsSdkVersion"
+    // Take out jackson libraries out to avoid collision with core jackson dependencies
+    implementation ("com.amazonaws:aws-java-sdk-s3:$awsSdkVersion") {
+        exclude group: "com.fasterxml.jackson.core"
+        exclude group: "com.fasterxml.jackson.dataformat"
+    }
+    // replacing with version used by core
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion"
 
     testImplementation(testFixtures(project(":storage:core")))
 


### PR DESCRIPTION
Fix #254 

The dependency issue reported on #254 is not between the version used by the plugin and the broker (as stated in the comments, it's handled by a custom class loader on the broker side); but by different versions used on the core and s3 module.

This PR includes the build changes to handle this exclusion, and the exception handling to capture this. Also some additional logging improvements.