### PR TITLE
Store remote log segment metadata

### DIFF
--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -55,6 +55,7 @@ import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
 import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.manifest.serde.EncryptionSerdeModule;
+import io.aiven.kafka.tieredstorage.manifest.serde.KafkaTypeSerdeModule;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataSerde;
 import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
@@ -325,6 +326,7 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
         // 3. The AAD is used.
 
         final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(KafkaTypeSerdeModule.create());
         final JsonNode manifest = objectMapper.readTree(new File(targetDir.toString(), TARGET_MANIFEST_FILE));
 
         final String dataKeyText = manifest.get("encryption").get("dataKey").asText();

--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -17,7 +17,6 @@
 package io.aiven.kafka.tieredstorage;
 
 import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -55,8 +54,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
 import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
-import io.aiven.kafka.tieredstorage.manifest.serde.DataKeyDeserializer;
-import io.aiven.kafka.tieredstorage.manifest.serde.DataKeySerializer;
+import io.aiven.kafka.tieredstorage.manifest.serde.EncryptionSerdeModule;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataSerde;
 import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
@@ -66,7 +64,6 @@ import io.aiven.kafka.tieredstorage.security.RsaEncryptionProvider;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.github.luben.zstd.Zstd;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
@@ -338,13 +335,8 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
         final byte[] dataKey = rsaEncryptionProvider.decryptDataKey(
             new EncryptedDataKey(KEY_ENCRYPTION_KEY_ID, encryptedDataKey));
         final byte[] aad = manifest.get("encryption").get("aad").binaryValue();
+        objectMapper.registerModule(EncryptionSerdeModule.create(rsaEncryptionProvider));
 
-        final SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addSerializer(SecretKey.class,
-            new DataKeySerializer(rsaEncryptionProvider::encryptDataKey));
-        simpleModule.addDeserializer(SecretKey.class,
-            new DataKeyDeserializer(rsaEncryptionProvider::decryptDataKey));
-        objectMapper.registerModule(simpleModule);
         final ChunkIndex chunkIndex = objectMapper.treeToValue(manifest.get("chunkIndex"), ChunkIndex.class);
 
         try (final InputStream originalInputStream = Files.newInputStream(logFilePath);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -50,6 +50,7 @@ import io.aiven.kafka.tieredstorage.manifest.SegmentManifestProvider;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.manifest.serde.EncryptionSerdeModule;
+import io.aiven.kafka.tieredstorage.manifest.serde.KafkaTypeSerdeModule;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataBuilder;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataSerde;
@@ -174,6 +175,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
     private ObjectMapper getObjectMapper() {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(KafkaTypeSerdeModule.create());
         if (encryptionEnabled) {
             objectMapper.registerModule(EncryptionSerdeModule.create(rsaEncryptionProvider));
         }
@@ -218,7 +220,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
             final ChunkIndex chunkIndex = transformFinisher.chunkIndex();
             final SegmentManifest segmentManifest =
-                new SegmentManifestV1(chunkIndex, requiresCompression, encryptionMetadata);
+                new SegmentManifestV1(chunkIndex, requiresCompression, encryptionMetadata, remoteLogSegmentMetadata);
             uploadManifest(remoteLogSegmentMetadata, segmentManifest, customMetadataBuilder);
 
             final InputStream offsetIndex = Files.newInputStream(logSegmentData.offsetIndex());

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifest.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifest.java
@@ -18,6 +18,8 @@ package io.aiven.kafka.tieredstorage.manifest;
 
 import java.util.Optional;
 
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -38,4 +40,6 @@ public interface SegmentManifest {
     boolean compression();
 
     Optional<SegmentEncryptionMetadata> encryption();
+
+    RemoteLogSegmentMetadata remoteLogSegmentMetadata();
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1.java
@@ -19,6 +19,8 @@ package io.aiven.kafka.tieredstorage.manifest;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -29,6 +31,7 @@ public class SegmentManifestV1 implements SegmentManifest {
     private final ChunkIndex chunkIndex;
     private final boolean compression;
     private final SegmentEncryptionMetadataV1 encryption;
+    private final RemoteLogSegmentMetadata remoteLogSegmentMetadata;
 
     @JsonCreator
     public SegmentManifestV1(@JsonProperty(value = "chunkIndex", required = true)
@@ -37,10 +40,19 @@ public class SegmentManifestV1 implements SegmentManifest {
                              final boolean compression,
                              @JsonProperty("encryption")
                              final SegmentEncryptionMetadataV1 encryption) {
+        this(chunkIndex, compression, encryption, null);
+    }
+
+    public SegmentManifestV1(final ChunkIndex chunkIndex,
+                             final boolean compression,
+                             final SegmentEncryptionMetadataV1 encryption,
+                             final RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
         this.chunkIndex = Objects.requireNonNull(chunkIndex, "chunkIndex cannot be null");
         this.compression = compression;
 
         this.encryption = encryption;
+
+        this.remoteLogSegmentMetadata = remoteLogSegmentMetadata;
     }
 
     @Override
@@ -63,6 +75,13 @@ public class SegmentManifestV1 implements SegmentManifest {
     }
 
     @Override
+    // We don't need to deserialize it
+    @JsonProperty(value = "remoteLogSegmentMetadata", access = JsonProperty.Access.READ_ONLY)
+    public RemoteLogSegmentMetadata remoteLogSegmentMetadata() {
+        return remoteLogSegmentMetadata;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -79,6 +98,7 @@ public class SegmentManifestV1 implements SegmentManifest {
         if (!chunkIndex.equals(that.chunkIndex)) {
             return false;
         }
+        // We don't want remoteLogSegmentMetadata to participate in hash code and equality checks.
         return Objects.equals(encryption, that.encryption);
     }
 
@@ -87,6 +107,7 @@ public class SegmentManifestV1 implements SegmentManifest {
         int result = chunkIndex.hashCode();
         result = 31 * result + (compression ? 1 : 0);
         result = 31 * result + (encryption != null ? encryption.hashCode() : 0);
+        // We don't want remoteLogSegmentMetadata to participate in hash code and equality checks.
         return result;
     }
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/DataKeyDeserializer.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/DataKeyDeserializer.java
@@ -30,10 +30,10 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
-public class DataKeyDeserializer extends StdDeserializer<SecretKey> {
+class DataKeyDeserializer extends StdDeserializer<SecretKey> {
     private final Function<EncryptedDataKey, byte[]> keyDecryptor;
 
-    public DataKeyDeserializer(final Function<EncryptedDataKey, byte[]> keyDecryptor) {
+    DataKeyDeserializer(final Function<EncryptedDataKey, byte[]> keyDecryptor) {
         super(SecretKey.class);
         this.keyDecryptor = Objects.requireNonNull(keyDecryptor, "keyDecryptor cannot be null");
     }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/DataKeySerializer.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/DataKeySerializer.java
@@ -28,10 +28,10 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-public class DataKeySerializer extends StdSerializer<SecretKey> {
+class DataKeySerializer extends StdSerializer<SecretKey> {
     private final Function<byte[], EncryptedDataKey> dataKeyEncryptor;
 
-    public DataKeySerializer(final Function<byte[], EncryptedDataKey> dataKeyEncryptor) {
+    DataKeySerializer(final Function<byte[], EncryptedDataKey> dataKeyEncryptor) {
         super(SecretKey.class);
         this.dataKeyEncryptor = Objects.requireNonNull(dataKeyEncryptor, "dataKeyEncryptor cannot be null");
     }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/EncryptionSerdeModule.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/EncryptionSerdeModule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest.serde;
+
+import javax.crypto.SecretKey;
+
+import io.aiven.kafka.tieredstorage.security.RsaEncryptionProvider;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public final class EncryptionSerdeModule {
+    public static Module create(final RsaEncryptionProvider rsaEncryptionProvider) {
+        final var module = new SimpleModule();
+
+        module.addSerializer(SecretKey.class,
+            new DataKeySerializer(rsaEncryptionProvider::encryptDataKey));
+        module.addDeserializer(SecretKey.class,
+            new DataKeyDeserializer(rsaEncryptionProvider::decryptDataKey));
+
+        return module;
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/KafkaTypeSerdeModule.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/serde/KafkaTypeSerdeModule.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest.serde;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class KafkaTypeSerdeModule {
+    public static Module create() {
+        final var module = new SimpleModule();
+
+        module.addSerializer(Uuid.class, new UuidSerializer());
+
+        module.setMixInAnnotation(TopicPartition.class, TopicPartitionSerdeMixin.class);
+        module.setMixInAnnotation(TopicIdPartition.class, TopicIdPartitionSerdeMixin.class);
+        module.setMixInAnnotation(RemoteLogSegmentId.class, RemoteLogSegmentIdMixin.class);
+        module.setMixInAnnotation(RemoteLogSegmentMetadata.class, RemoteLogSegmentMetadataMixin.class);
+
+        return module;
+    }
+
+    private static class UuidSerializer extends StdSerializer<Uuid> {
+        UuidSerializer() {
+            super(Uuid.class);
+        }
+
+        @Override
+        public void serialize(final Uuid value,
+                              final JsonGenerator gen,
+                              final SerializerProvider provider) throws IOException {
+            gen.writeString(value.toString());
+        }
+    }
+
+    @JsonPropertyOrder({ "topic", "partition" })
+    private abstract static class TopicPartitionSerdeMixin {
+        @JsonProperty("topic")
+        public abstract String topic();
+
+        @JsonProperty("partition")
+        public abstract int partition();
+    }
+
+    @JsonPropertyOrder({ "topicId", "topicPartition" })
+    private abstract static class TopicIdPartitionSerdeMixin {
+        @JsonProperty("topicId")
+        public abstract Uuid topicId();
+
+        @JsonProperty("topicPartition")
+        public abstract TopicPartition topicPartition();
+    }
+
+    @JsonPropertyOrder({ "topicIdPartition", "id" })
+    private abstract static class RemoteLogSegmentIdMixin {
+        @JsonProperty("topicIdPartition")
+        abstract TopicIdPartition topicIdPartition();
+
+        @JsonProperty("id")
+        abstract Uuid id();
+    }
+
+    @JsonPropertyOrder({
+        "remoteLogSegmentId", "startOffset", "endOffset",
+        "maxTimestampMs", "brokerId", "eventTimestampMs", "segmentLeaderEpochs"
+    })
+    private abstract static class RemoteLogSegmentMetadataMixin {
+        @JsonProperty("remoteLogSegmentId")
+        public abstract RemoteLogSegmentId remoteLogSegmentId();
+
+        @JsonProperty("startOffset")
+        public abstract long startOffset();
+
+        @JsonProperty("endOffset")
+        public abstract long endOffset();
+
+        @JsonProperty("maxTimestampMs")
+        public abstract long maxTimestampMs();
+
+        @JsonProperty("brokerId")
+        public abstract int brokerId();
+
+        @JsonProperty("eventTimestampMs")
+        public abstract long eventTimestampMs();
+
+        @JsonProperty("segmentLeaderEpochs")
+        public abstract Map<Integer, Long> segmentLeaderEpochs();
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -149,9 +149,9 @@ class RemoteStorageManagerMetricsTest {
             .isEqualTo(18.0 / METRIC_TIME_WINDOW_SEC);
 
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-bytes-total"))
-            .isEqualTo(657.0);
+            .isEqualTo(1575.0);
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-bytes-rate"))
-            .isEqualTo(657.0 / METRIC_TIME_WINDOW_SEC);
+            .isEqualTo(1575.0 / METRIC_TIME_WINDOW_SEC);
 
         for (final var suffix : ObjectKey.Suffix.values()) {
             final ObjectName storageMetricsName = ObjectName.getInstance(objectName + ",object-type=" + suffix.value);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/DefaultChunkManagerTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/DefaultChunkManagerTest.java
@@ -51,7 +51,7 @@ class DefaultChunkManagerTest extends AesKeyAwareTest {
     void testGetChunk() throws Exception {
         final FixedSizeChunkIndex chunkIndex = new FixedSizeChunkIndex(10, 10, 10, 10);
 
-        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null);
+        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null, null);
         final ChunkManager chunkManager = new DefaultChunkManager(storage, null);
         when(storage.fetch(OBJECT_KEY_PATH, chunkIndex.chunks().get(0).range()))
                 .thenReturn(new ByteArrayInputStream("0123456789".getBytes()));
@@ -77,7 +77,7 @@ class DefaultChunkManagerTest extends AesKeyAwareTest {
             new ByteArrayInputStream(encrypted));
 
         final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false,
-            new SegmentEncryptionMetadataV1(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad));
+            new SegmentEncryptionMetadataV1(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad), null);
         final ChunkManager chunkManager = new DefaultChunkManager(storage, aesEncryptionProvider);
 
         assertThat(chunkManager.getChunk(OBJECT_KEY_PATH, manifest, 0)).hasBinaryContent(TEST_CHUNK_CONTENT);
@@ -97,7 +97,7 @@ class DefaultChunkManagerTest extends AesKeyAwareTest {
         when(storage.fetch(OBJECT_KEY_PATH, chunkIndex.chunks().get(0).range()))
                 .thenReturn(new ByteArrayInputStream(compressed));
 
-        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, true, null);
+        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, true, null, null);
         final ChunkManager chunkManager = new DefaultChunkManager(storage, null);
 
         assertThat(chunkManager.getChunk(OBJECT_KEY_PATH, manifest, 0)).hasBinaryContent(TEST_CHUNK_CONTENT);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheTest.java
@@ -64,7 +64,8 @@ class ChunkCacheTest {
     private static final byte[] CHUNK_0 = "0123456789".getBytes();
     private static final byte[] CHUNK_1 = "1011121314".getBytes();
     private static final FixedSizeChunkIndex FIXED_SIZE_CHUNK_INDEX = new FixedSizeChunkIndex(10, 10, 10, 10);
-    private static final SegmentManifest SEGMENT_MANIFEST = new SegmentManifestV1(FIXED_SIZE_CHUNK_INDEX, false, null);
+    private static final SegmentManifest SEGMENT_MANIFEST =
+        new SegmentManifestV1(FIXED_SIZE_CHUNK_INDEX, false, null, null);
     private static final String TEST_EXCEPTION_MESSAGE = "test_message";
     private static final String SEGMENT_KEY = "topic/segment";
     @Mock

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestProviderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestProviderTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
+import io.aiven.kafka.tieredstorage.manifest.serde.KafkaTypeSerdeModule;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
 
@@ -51,6 +52,7 @@ class SegmentManifestProviderTest {
 
     static {
         MAPPER.registerModule(new Jdk8Module());
+        MAPPER.registerModule(KafkaTypeSerdeModule.create());
     }
 
     static final String MANIFEST =
@@ -94,7 +96,7 @@ class SegmentManifestProviderTest {
             .thenReturn(new ByteArrayInputStream(MANIFEST.getBytes()));
         final SegmentManifestV1 expectedManifest = new SegmentManifestV1(
             new FixedSizeChunkIndex(100, 1000, 110, 110),
-            false, null
+            false, null, null
         );
         assertThat(provider.get(key)).isEqualTo(expectedManifest);
         verify(storage).fetch(key);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1SerdeTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1SerdeTest.java
@@ -23,14 +23,12 @@ import java.util.Base64;
 
 import io.aiven.kafka.tieredstorage.RsaKeyAwareTest;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
-import io.aiven.kafka.tieredstorage.manifest.serde.DataKeyDeserializer;
-import io.aiven.kafka.tieredstorage.manifest.serde.DataKeySerializer;
+import io.aiven.kafka.tieredstorage.manifest.serde.EncryptionSerdeModule;
 import io.aiven.kafka.tieredstorage.security.EncryptedDataKey;
 import io.aiven.kafka.tieredstorage.security.RsaEncryptionProvider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,13 +62,7 @@ class SegmentManifestV1SerdeTest extends RsaKeyAwareTest {
         mapper.registerModule(new Jdk8Module());
 
         rsaEncryptionProvider = new RsaEncryptionProvider(KEY_ENCRYPTION_KEY_ID, keyRing);
-
-        final SimpleModule simpleModule = new SimpleModule();
-        simpleModule.addSerializer(SecretKey.class,
-            new DataKeySerializer(rsaEncryptionProvider::encryptDataKey));
-        simpleModule.addDeserializer(SecretKey.class,
-            new DataKeyDeserializer(rsaEncryptionProvider::decryptDataKey));
-        mapper.registerModule(simpleModule);
+        mapper.registerModule(EncryptionSerdeModule.create(rsaEncryptionProvider));
     }
 
     @Test

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationSourceInputStreamClosingTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationSourceInputStreamClosingTest.java
@@ -62,7 +62,7 @@ class FetchChunkEnumerationSourceInputStreamClosingTest {
     static final FixedSizeChunkIndex CHUNK_INDEX = new FixedSizeChunkIndex(
         CHUNK_SIZE, CHUNK_SIZE * 3, CHUNK_SIZE, CHUNK_SIZE);
     static final SegmentManifest SEGMENT_MANIFEST = new SegmentManifestV1(
-        CHUNK_INDEX, false, null);
+        CHUNK_INDEX, false, null, null);
 
     TestObjectFetcher fetcher;
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
@@ -41,7 +41,7 @@ class FetchChunkEnumerationTest {
     DefaultChunkManager chunkManager;
 
     final FixedSizeChunkIndex chunkIndex = new FixedSizeChunkIndex(10, 100, 10, 100);
-    final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null);
+    final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null, null);
 
     static final byte[] CHUNK_CONTENT = "0123456789".getBytes();
     static final String SEGMENT_KEY_PATH = "topic/segment";
@@ -52,7 +52,7 @@ class FetchChunkEnumerationTest {
     @Test
     void failsWhenLargerStartPosition() {
         // Given
-        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null);
+        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null, null);
         // When
         final int from = 1000;
         final int to = from + 1;


### PR DESCRIPTION
To make the segments more self-contained, this commits adds the remote log segment metadata in the manifest. However, it doesn't serialize it back (we don't need it).

Closes https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/issues/158