### PR TITLE
Correctly throw RemoteResourceNotFoundException

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -75,6 +75,7 @@ import io.aiven.kafka.tieredstorage.transform.DetransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.DetransformFinisher;
 import io.aiven.kafka.tieredstorage.transform.EncryptionChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.FetchChunkEnumeration;
+import io.aiven.kafka.tieredstorage.transform.KeyNotFoundRuntimeException;
 import io.aiven.kafka.tieredstorage.transform.TransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.TransformFinisher;
 
@@ -388,6 +389,8 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
             return new FetchChunkEnumeration(chunkManager, segmentKey, segmentManifest, range)
                 .toInputStream();
+        } catch (final KeyNotFoundException | KeyNotFoundRuntimeException e) {
+            throw new RemoteResourceNotFoundException(e);
         } catch (final Exception e) {
             throw new RemoteStorageException(e);
         }
@@ -415,14 +418,11 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             }
             final DetransformFinisher detransformFinisher = new DetransformFinisher(detransformEnum);
             return detransformFinisher.toInputStream();
+        } catch (final KeyNotFoundException e) {
+            throw new RemoteResourceNotFoundException(e);
         } catch (final Exception e) {
-            if (e instanceof KeyNotFoundException) {
-                throw new RemoteResourceNotFoundException(e);
-            } else {
-                throw new RemoteStorageException(e);
-            }
+            throw new RemoteStorageException(e);
         }
-
     }
 
     private String objectKey(final RemoteLogSegmentMetadata remoteLogSegmentMetadata, final ObjectKey.Suffix suffix) {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumeration.java
@@ -29,6 +29,7 @@ import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.storage.BytesRange;
+import io.aiven.kafka.tieredstorage.storage.KeyNotFoundException;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
 
 import org.apache.commons.io.input.BoundedInputStream;
@@ -137,6 +138,8 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
     private InputStream getChunkContent(final int chunkId) {
         try {
             return chunkManager.getChunk(objectKeyPath, manifest, chunkId);
+        } catch (final KeyNotFoundException e) {
+            throw new KeyNotFoundRuntimeException(e);
         } catch (final StorageBackendException | IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/KeyNotFoundRuntimeException.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/KeyNotFoundRuntimeException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.transform;
+
+import io.aiven.kafka.tieredstorage.storage.KeyNotFoundException;
+
+public class KeyNotFoundRuntimeException extends RuntimeException {
+    KeyNotFoundRuntimeException(final KeyNotFoundException keyNotFoundException) {
+        super(keyNotFoundException);
+    }
+}


### PR DESCRIPTION
This commit makes `RemoteStorageManager` throw `RemoteResourceNotFoundException` on the fetch operation when the requested object (or the manifest object) is not found.

Closes #180
