### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = True
+
+[*]
+end_of_line = lf
+insert_final_newline = True
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = True
+
+[*.{yml,yaml,md,toml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Makes supporting editors (which is many of them) behave consistently, mine was using spaces for indentation in the Makefile without this.