### PR TITLE
chore: update Kafka image with latest 3.6 changes

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.log.remote.storage.LogSegmentData;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata.CustomMetadata;
+import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundException;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
@@ -62,6 +63,7 @@ import io.aiven.kafka.tieredstorage.security.DataKeyAndAAD;
 import io.aiven.kafka.tieredstorage.security.RsaEncryptionProvider;
 import io.aiven.kafka.tieredstorage.security.RsaKeyReader;
 import io.aiven.kafka.tieredstorage.storage.BytesRange;
+import io.aiven.kafka.tieredstorage.storage.KeyNotFoundException;
 import io.aiven.kafka.tieredstorage.storage.ObjectDeleter;
 import io.aiven.kafka.tieredstorage.storage.ObjectFetcher;
 import io.aiven.kafka.tieredstorage.storage.ObjectUploader;
@@ -421,9 +423,8 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             final DetransformFinisher detransformFinisher = new DetransformFinisher(detransformEnum);
             return detransformFinisher.toInputStream();
         } catch (final Exception e) {
-            // TODO: should be aligned with upstream implementation
-            if (indexType == TRANSACTION) {
-                return null;
+            if (e instanceof KeyNotFoundException) {
+                throw new RemoteResourceNotFoundException(e);
             } else {
                 throw new RemoteStorageException(e);
             }

--- a/demo/compose-local-fs.yml
+++ b/demo/compose-local-fs.yml
@@ -61,6 +61,7 @@ services:
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 5242880 # 5MiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: -1
+      KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE: "REMOTE_SIZE"
       # Storage backend
       KAFKA_RSM_CONFIG_KEY_PREFIX: "tiered-storage-demo/"
       KAFKA_RSM_CONFIG_STORAGE_BACKEND_CLASS: "io.aiven.kafka.tieredstorage.storage.filesystem.FileSystemStorage"

--- a/demo/compose-s3-aws.yml
+++ b/demo/compose-s3-aws.yml
@@ -61,6 +61,7 @@ services:
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 5242880 # 5MiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: -1
+      KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE: "REMOTE_SIZE"
       # Storage backend
       KAFKA_RSM_CONFIG_KEY_PREFIX: "tiered-storage-demo/"
       KAFKA_RSM_CONFIG_STORAGE_BACKEND_CLASS: "io.aiven.kafka.tieredstorage.storage.s3.S3Storage"

--- a/demo/compose-s3-minio.yml
+++ b/demo/compose-s3-minio.yml
@@ -62,6 +62,7 @@ services:
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 5242880 # 5MiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: -1
+      KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE: "REMOTE_SIZE"
       # Storage backend
       KAFKA_RSM_CONFIG_KEY_PREFIX: "tiered-storage-demo/"
       KAFKA_RSM_CONFIG_STORAGE_BACKEND_CLASS: "io.aiven.kafka.tieredstorage.storage.s3.S3Storage"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-FROM aivenoy/kafka:kips_KIP-405_3.6-2023-09-06
+FROM aivenoy/kafka:kips_KIP-405_3.6-2023-09-12
 
 ARG _VERSION
 

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -156,6 +156,7 @@ abstract class SingleBrokerTest {
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS",
                 "io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE", "-1")
+            .withEnv("KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE", "REMOTE_SIZE")
             // other tweaks
             .withEnv("KAFKA_OPTS", "") // disable JMX exporter
             .withEnv("KAFKA_LOG4J_LOGGERS", "io.aiven.kafka.tieredstorage=DEBUG,"


### PR DESCRIPTION
Main changes:
- Update base docker image, based on https://github.com/aiven/kafka/pull/41
- Fix how to handle exception when key is not found
- Use custom metadata on demo and E2E tests
