### PR TITLE
Add option to disable SSL cert verification in the S3 client

### DIFF
--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
@@ -51,6 +51,7 @@ class S3StorageConfigTest {
         assertThat(config.credentialsProvider()).isNull();
         assertThat(config.pathStyleAccessEnabled()).isNull();
         assertThat(config.uploadPartSize()).isEqualTo(S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT);
+        assertThat(config.disableAwsCertChecking()).isEqualTo(false);
 
         verifyClientConfiguration(config.s3Client(), null);
     }
@@ -108,7 +109,8 @@ class S3StorageConfigTest {
             "s3.region", region.id(),
             "s3.endpoint.url", MINIO_URL,
             "aws.access.key.id", username,
-            "aws.secret.access.key", password);
+            "aws.secret.access.key", password,
+            "storage.disableAWSCertChecking", "true");
 
         final var config = new S3StorageConfig(configs);
 
@@ -117,6 +119,7 @@ class S3StorageConfigTest {
         assertThat(config.getString("s3.endpoint.url")).isEqualTo(MINIO_URL);
         assertThat(config.getPassword("aws.access.key.id").value()).isEqualTo(username);
         assertThat(config.getPassword("aws.secret.access.key").value()).isEqualTo(password);
+        assertThat(config.disableAwsCertChecking()).isEqualTo(true);
 
         final AwsCredentialsProvider credentialsProvider = config.credentialsProvider();
         assertThat(credentialsProvider).isInstanceOf(StaticCredentialsProvider.class);


### PR DESCRIPTION
It adds an option to disable the ssl cert verification, it's useful in testing scenario when it's hard/complex to install the generated root certificate into the kafka hosting machine.
