### PR TITLE
feat: Disable S3 checksum validation

### DIFF
--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -81,10 +81,10 @@ public class S3StorageConfig extends AbstractConfig {
     public static final String AWS_SECRET_ACCESS_KEY_CONFIG = "aws.secret.access.key";
     private static final String AWS_SECRET_ACCESS_KEY_DOC = "AWS secret access key. "
         + "To be used when static credentials are provided.";
-    public static final String DISABLE_AWS_CERT_CHECKING_CONFIG = "aws.disable.cert.checking";
-    private static final String DISABLE_AWS_CERT_CHECKING_DOC =
-        "This property is used to disable SSL certificate checking for AWS services. "
-            + "When set to \"true\", the SSL certificate checking for AWS services will be bypassed. "
+    public static final String AWS_CERTIFICATE_CHECK_ENABLED_CONFIG = "aws.certificate.check.enabled";
+    private static final String AWS_CERTIFICATE_CHECK_ENABLED_DOC =
+        "This property is used to enable SSL certificate checking for AWS services. "
+            + "When set to \"false\", the SSL certificate checking for AWS services will be bypassed. "
             + "Use with caution and always only in a test environment, as disabling certificate lead the storage "
             + "to be vulnerable to man-in-the-middle attacks.";
 
@@ -161,11 +161,11 @@ public class S3StorageConfig extends AbstractConfig {
                 new NonEmptyPassword(),
                 ConfigDef.Importance.MEDIUM,
                 AWS_SECRET_ACCESS_KEY_DOC)
-            .define(DISABLE_AWS_CERT_CHECKING_CONFIG,
+            .define(AWS_CERTIFICATE_CHECK_ENABLED_CONFIG,
                 ConfigDef.Type.BOOLEAN,
-                false,
+                true,
                 ConfigDef.Importance.LOW,
-                DISABLE_AWS_CERT_CHECKING_DOC
+                AWS_CERTIFICATE_CHECK_ENABLED_DOC
             );
     }
 
@@ -207,7 +207,7 @@ public class S3StorageConfig extends AbstractConfig {
             s3ClientBuilder.forcePathStyle(pathStyleAccessEnabled);
         }
 
-        if (disableAwsCertChecking()) {
+        if (!certificateCheckEnabled()) {
             s3ClientBuilder.httpClient(
                 new DefaultSdkHttpClientBuilder()
                     .buildWithDefaults(
@@ -263,8 +263,8 @@ public class S3StorageConfig extends AbstractConfig {
         }
     }
 
-    public Boolean disableAwsCertChecking() {
-        return getBoolean(DISABLE_AWS_CERT_CHECKING_CONFIG);
+    public Boolean certificateCheckEnabled() {
+        return getBoolean(AWS_CERTIFICATE_CHECK_ENABLED_CONFIG);
     }
 
     public String bucketName() {

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -88,6 +88,12 @@ public class S3StorageConfig extends AbstractConfig {
             + "Use with caution and always only in a test environment, as disabling certificate lead the storage "
             + "to be vulnerable to man-in-the-middle attacks.";
 
+    public static final String AWS_CHECKSUM_CHECK_ENABLED_CONFIG = "aws.checksum.check.enabled";
+    private static final String AWS_CHECKSUM_CHECK_ENABLED_DOC =
+        "This property is used to enable checksum validation done by AWS library. "
+            + "When set to \"false\", there will be no validation. "
+            + "It is disabled by default as Kafka already validates integrity of the files.";
+
 
     private static final ConfigDef CONFIG;
 
@@ -166,6 +172,12 @@ public class S3StorageConfig extends AbstractConfig {
                 true,
                 ConfigDef.Importance.LOW,
                 AWS_CERTIFICATE_CHECK_ENABLED_DOC
+            )
+            .define(AWS_CHECKSUM_CHECK_ENABLED_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                false,
+                ConfigDef.Importance.MEDIUM,
+                AWS_CHECKSUM_CHECK_ENABLED_DOC
             );
     }
 
@@ -218,6 +230,8 @@ public class S3StorageConfig extends AbstractConfig {
             );
         }
 
+        s3ClientBuilder.serviceConfiguration(builder -> builder.checksumValidationEnabled(checksumCheckEnabled()));
+
         final AwsCredentialsProvider credentialsProvider = credentialsProvider();
         if (credentialsProvider != null) {
             s3ClientBuilder.credentialsProvider(credentialsProvider);
@@ -265,6 +279,10 @@ public class S3StorageConfig extends AbstractConfig {
 
     public Boolean certificateCheckEnabled() {
         return getBoolean(AWS_CERTIFICATE_CHECK_ENABLED_CONFIG);
+    }
+
+    public Boolean checksumCheckEnabled() {
+        return getBoolean(AWS_CHECKSUM_CHECK_ENABLED_CONFIG);
     }
 
     public String bucketName() {

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
@@ -53,6 +53,7 @@ class S3StorageConfigTest {
         assertThat(config.pathStyleAccessEnabled()).isNull();
         assertThat(config.uploadPartSize()).isEqualTo(S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT);
         assertThat(config.certificateCheckEnabled()).isTrue();
+        assertThat(config.checksumCheckEnabled()).isFalse();
         verifyClientConfiguration(config.s3Client(), null);
     }
 
@@ -110,7 +111,8 @@ class S3StorageConfigTest {
             "s3.endpoint.url", MINIO_URL,
             "aws.access.key.id", username,
             "aws.secret.access.key", password,
-            "aws.certificate.check.enabled", "false");
+            "aws.certificate.check.enabled", "false",
+            "aws.checksum.check.enabled", "true");
 
         final var config = new S3StorageConfig(configs);
 
@@ -120,6 +122,7 @@ class S3StorageConfigTest {
         assertThat(config.getPassword("aws.access.key.id").value()).isEqualTo(username);
         assertThat(config.getPassword("aws.secret.access.key").value()).isEqualTo(password);
         assertThat(config.certificateCheckEnabled()).isFalse();
+        assertThat(config.checksumCheckEnabled()).isTrue();
 
         final AwsCredentialsProvider credentialsProvider = config.credentialsProvider();
         assertThat(credentialsProvider).isInstanceOf(StaticCredentialsProvider.class);

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
@@ -52,7 +52,7 @@ class S3StorageConfigTest {
         assertThat(config.credentialsProvider()).isNull();
         assertThat(config.pathStyleAccessEnabled()).isNull();
         assertThat(config.uploadPartSize()).isEqualTo(S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT);
-        assertThat(config.disableAwsCertChecking()).isFalse();
+        assertThat(config.certificateCheckEnabled()).isTrue();
         verifyClientConfiguration(config.s3Client(), null);
     }
 
@@ -110,7 +110,7 @@ class S3StorageConfigTest {
             "s3.endpoint.url", MINIO_URL,
             "aws.access.key.id", username,
             "aws.secret.access.key", password,
-            "aws.disable.cert.checking", "true");
+            "aws.certificate.check.enabled", "false");
 
         final var config = new S3StorageConfig(configs);
 
@@ -119,7 +119,7 @@ class S3StorageConfigTest {
         assertThat(config.getString("s3.endpoint.url")).isEqualTo(MINIO_URL);
         assertThat(config.getPassword("aws.access.key.id").value()).isEqualTo(username);
         assertThat(config.getPassword("aws.secret.access.key").value()).isEqualTo(password);
-        assertThat(config.disableAwsCertChecking()).isEqualTo(true);
+        assertThat(config.certificateCheckEnabled()).isFalse();
 
         final AwsCredentialsProvider credentialsProvider = config.credentialsProvider();
         assertThat(credentialsProvider).isInstanceOf(StaticCredentialsProvider.class);


### PR DESCRIPTION
Adds configuration flag to disable checksum validation, and disables it by default.

We have observed that checksum validation adds ~20% more load when fetching logs. At the moment is not clear how to handle checksum issues; so this PR proposes to let Kafka handle any integrity when reading from a log. If this feature wants to be enabled, there is a new configuration to do this.

No checksum validation:
![image](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/assets/6180701/fac72d48-ecb1-4d65-854b-a976bd7406f9)

Checksum validation:
![image](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/assets/6180701/045bbc65-c2e9-48a2-b9c4-2a0027cf5ec7)

![image](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/assets/6180701/efa57ffc-ebda-4255-8d28-c1d2693d978d)

