### PR TITLE
fix: use index instead of ordinal for metadata fields

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataBuilder.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metadata/SegmentCustomMetadataBuilder.java
@@ -60,7 +60,7 @@ public class SegmentCustomMetadataBuilder {
      */
     public NavigableMap<Integer, Object> build() {
         final TreeMap<Integer, Object> taggedFields = new TreeMap<>();
-        fields.forEach(field -> taggedFields.put(field.ordinal(), field.valueProvider.apply(this)));
+        fields.forEach(field -> taggedFields.put(field.index(), field.valueProvider.apply(this)));
         return taggedFields;
     }
 }


### PR DESCRIPTION
Complete the suggestion proposed here [1]

[1]: https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/pull/351#discussion_r1295888748
