### PR TITLE
feat: group indexes to save remote tier calls

### DIFF
--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -227,7 +227,7 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
             rsm.copyLogSegmentData(REMOTE_LOG_METADATA, logSegmentData);
 
         checkCustomMetadata(customMetadata);
-        checkFilesInTargetDirectory(hasTxnIndex);
+        checkFilesInTargetDirectory();
         checkManifest(chunkSize, compression, encryption);
         if (encryption) {
             checkEncryption(compression);
@@ -252,17 +252,12 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
             .isNotEmpty();
     }
 
-    private void checkFilesInTargetDirectory(final boolean hasTxnIndex) {
+    private void checkFilesInTargetDirectory() {
         final List<String> expectedFiles = new ArrayList<>(List.of(
             TARGET_LOG_FILE,
-            "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000000023-AAAAAAAAAAAAAAAAAAAAAA.timeindex",
-            "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000000023-AAAAAAAAAAAAAAAAAAAAAA.snapshot",
-            "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000000023-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint",
+            "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000000023-AAAAAAAAAAAAAAAAAAAAAA.indexes",
             TARGET_MANIFEST_FILE
         ));
-        if (hasTxnIndex) {
-            expectedFiles.add("topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000000023-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        }
         expectedFiles.forEach(s ->
             assertThat(targetDir).isDirectoryRecursivelyContaining(path -> path.toString().endsWith(s)));
     }
@@ -542,7 +537,7 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
 
         // Make sure the exception is connected to the index file.
         final String expectedMessage = "Key "
-            + objectKeyFactory.key(REMOTE_LOG_METADATA, ObjectKeyFactory.Suffix.fromIndexType(indexType))
+            + objectKeyFactory.key(REMOTE_LOG_METADATA, ObjectKeyFactory.Suffix.INDEXES)
             + " does not exists in storage";
 
         assertThatThrownBy(() -> rsm.fetchIndex(REMOTE_LOG_METADATA, indexType))

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/ObjectKeyFactory.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/ObjectKeyFactory.java
@@ -24,7 +24,6 @@ import java.util.function.BiFunction;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
-import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
 
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 
@@ -43,29 +42,13 @@ public final class ObjectKeyFactory {
      */
     public enum Suffix {
         LOG("log"),
-        OFFSET_INDEX("index"),
-        TIME_INDEX("timeindex"),
-        PRODUCER_SNAPSHOT("snapshot"),
-        TXN_INDEX("txnindex"),
-        LEADER_EPOCH_CHECKPOINT("leader-epoch-checkpoint"),
+        INDEXES("indexes"),
         MANIFEST("rsm-manifest");
 
         public final String value;
 
         Suffix(final String value) {
             this.value = value;
-        }
-
-        static Suffix fromIndexType(final RemoteStorageManager.IndexType indexType) {
-            switch (indexType) {
-                case OFFSET: return OFFSET_INDEX;
-                case TIMESTAMP: return TIME_INDEX;
-                case PRODUCER_SNAPSHOT: return PRODUCER_SNAPSHOT;
-                case TRANSACTION: return TXN_INDEX;
-                case LEADER_EPOCH: return LEADER_EPOCH_CHECKPOINT;
-                default:
-                    throw new IllegalArgumentException("Unknown index type " + indexType);
-            }
         }
     }
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
@@ -65,6 +65,22 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
         "The retention time for the segment manifest cache. "
             + "Use -1 for \"forever\". The default is 3_600_000 (1 hour).";
 
+
+    private static final String SEGMENT_INDEXES_CACHE_PREFIX = "segment.indexes.cache.";
+    private static final String SEGMENT_INDEXES_CACHE_SIZE_CONFIG = SEGMENT_INDEXES_CACHE_PREFIX + "size";
+    private static final Long SEGMENT_INDEXES_CACHE_SIZE_DEFAULT = 1000L;  // TODO consider a better default
+    private static final String SEGMENT_INDEXES_CACHE_SIZE_DOC =
+        "The size in items of the segment manifest cache. "
+            + "Use -1 for \"unbounded\". The default is 1000.";
+
+    public static final String SEGMENT_INDEXES_CACHE_RETENTION_MS_CONFIG = SEGMENT_INDEXES_CACHE_PREFIX
+        + "retention.ms";
+    public static final long SEGMENT_INDEXES_CACHE_RETENTION_MS_DEFAULT = 3_600_000;  // 1 hour
+    private static final String SEGMENT_INDEXES_CACHE_RETENTION_MS_DOC =
+        "The retention time for the segment manifest cache. "
+            + "Use -1 for \"forever\". The default is 3_600_000 (1 hour).";
+
+
     private static final String CHUNK_SIZE_CONFIG = "chunk.size";
     private static final String CHUNK_SIZE_DOC = "The chunk size of log files";
 
@@ -141,6 +157,23 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
             ConfigDef.Range.atLeast(-1L),
             ConfigDef.Importance.LOW,
             SEGMENT_MANIFEST_CACHE_RETENTION_MS_DOC
+        );
+
+        CONFIG.define(
+            SEGMENT_INDEXES_CACHE_SIZE_CONFIG,
+            ConfigDef.Type.LONG,
+            SEGMENT_INDEXES_CACHE_SIZE_DEFAULT,
+            ConfigDef.Range.atLeast(-1L),
+            ConfigDef.Importance.LOW,
+            SEGMENT_INDEXES_CACHE_SIZE_DOC
+        );
+        CONFIG.define(
+            SEGMENT_INDEXES_CACHE_RETENTION_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            SEGMENT_INDEXES_CACHE_RETENTION_MS_DEFAULT,
+            ConfigDef.Range.atLeast(-1L),
+            ConfigDef.Importance.LOW,
+            SEGMENT_INDEXES_CACHE_RETENTION_MS_DOC
         );
 
         CONFIG.define(
@@ -336,6 +369,22 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
 
     public Optional<Duration> segmentManifestCacheRetention() {
         final long rawValue = getLong(SEGMENT_MANIFEST_CACHE_RETENTION_MS_CONFIG);
+        if (rawValue == -1) {
+            return Optional.empty();
+        }
+        return Optional.of(Duration.ofMillis(rawValue));
+    }
+
+    public Optional<Long> segmentIndexesCacheSize() {
+        final long rawValue = getLong(SEGMENT_INDEXES_CACHE_SIZE_CONFIG);
+        if (rawValue == -1) {
+            return Optional.empty();
+        }
+        return Optional.of(rawValue);
+    }
+
+    public Optional<Duration> segmentIndexesCacheRetention() {
+        final long rawValue = getLong(SEGMENT_INDEXES_CACHE_RETENTION_MS_CONFIG);
         if (rawValue == -1) {
             return Optional.empty();
         }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/index/SegmentIndex.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/index/SegmentIndex.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.index;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.server.log.remote.storage.LogSegmentData;
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
+
+import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.LEADER_EPOCH;
+import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.OFFSET;
+import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT;
+import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.TIMESTAMP;
+import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType.TRANSACTION;
+
+/**
+ * Defines the segment index fields to be collected together as a single object
+ */
+public enum SegmentIndex {
+    OFFSET_INDEX(0,
+        new Field(OFFSET.name(), Type.COMPACT_BYTES),
+        segmentData -> {
+            try {
+                return ByteBuffer.wrap(Files.readAllBytes(segmentData.offsetIndex()));
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }),
+    TIME_INDEX(1,
+        new Field(TIMESTAMP.name(), Type.COMPACT_BYTES),
+        segmentData -> {
+            try {
+                return ByteBuffer.wrap(Files.readAllBytes(segmentData.timeIndex()));
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }),
+    PRODUCER_SNAPSHOT_INDEX(2,
+        new Field(PRODUCER_SNAPSHOT.name(), Type.COMPACT_BYTES),
+        segmentData -> {
+            try {
+                return ByteBuffer.wrap(Files.readAllBytes(segmentData.producerSnapshotIndex()));
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }),
+    LEADER_EPOCH_INDEX(3, new Field(LEADER_EPOCH.name(), Type.COMPACT_BYTES), LogSegmentData::leaderEpochIndex),
+    TRANSACTION_INDEX(4,
+        new Field(TRANSACTION.name(), Type.COMPACT_NULLABLE_BYTES),
+        segmentData -> segmentData.transactionIndex()
+            .map(i -> {
+                try {
+                    return ByteBuffer.wrap(Files.readAllBytes(i));
+                } catch (final IOException e) {
+                    throw new RuntimeException(e);
+                }
+            })
+            .orElse(null));
+
+    static final Field.TaggedFieldsSection FIELDS_SECTION = Field.TaggedFieldsSection.of(
+        OFFSET_INDEX.index, OFFSET_INDEX.field,
+        TIME_INDEX.index, TIME_INDEX.field,
+        PRODUCER_SNAPSHOT_INDEX.index, PRODUCER_SNAPSHOT_INDEX.field,
+        LEADER_EPOCH_INDEX.index, LEADER_EPOCH_INDEX.field,
+        TRANSACTION_INDEX.index, TRANSACTION_INDEX.field
+    );
+    static final Map<String, Integer> KAFKA_MAPPING = Map.of(
+        OFFSET.name(), OFFSET_INDEX.index,
+        TIMESTAMP.name(), TIME_INDEX.index,
+        PRODUCER_SNAPSHOT.name(), PRODUCER_SNAPSHOT_INDEX.index,
+        LEADER_EPOCH.name(), LEADER_EPOCH_INDEX.index,
+        TRANSACTION.name(), TRANSACTION_INDEX.index
+    );
+    public static final Schema SEGMENT_INDEXES_SCHEMA = new Schema(FIELDS_SECTION);
+    public static final String TAGGED_FIELD_NAME = FIELDS_SECTION.name;
+
+    final int index;
+    final Field field;
+    final Function<LogSegmentData, ByteBuffer> valueProvider;
+
+    SegmentIndex(final int index,
+                 final Field field,
+                 final Function<LogSegmentData, ByteBuffer> valueProvider) {
+        this.index = index;
+        this.field = field;
+        this.valueProvider = valueProvider;
+    }
+
+    public static NavigableMap<Integer, Object> build(final LogSegmentData segmentData) {
+        final TreeMap<Integer, Object> taggedFields = new TreeMap<>();
+        for (final var index: SegmentIndex.values()) {
+            taggedFields.put(index.index, index.valueProvider.apply(segmentData));
+        }
+        return taggedFields;
+    }
+
+    public static Integer indexFrom(final RemoteStorageManager.IndexType indexType) {
+        return KAFKA_MAPPING.get(indexType.name());
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/index/SegmentIndexesProvider.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/index/SegmentIndexesProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.index;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadata;
+import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
+import io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter;
+import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
+import io.aiven.kafka.tieredstorage.storage.ObjectFetcher;
+import io.aiven.kafka.tieredstorage.storage.ObjectKey;
+import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
+import io.aiven.kafka.tieredstorage.transform.BaseDetransformChunkEnumeration;
+import io.aiven.kafka.tieredstorage.transform.DecryptionChunkEnumeration;
+import io.aiven.kafka.tieredstorage.transform.DetransformChunkEnumeration;
+import io.aiven.kafka.tieredstorage.transform.DetransformFinisher;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+public class SegmentIndexesProvider {
+    private static final String SEGMENT_MANIFEST_METRIC_GROUP_NAME = "segment-indexes-cache";
+    private static final long GET_TIMEOUT_SEC = 10;
+
+    private final AsyncLoadingCache<ObjectKey, NavigableMap<Integer, Object>> cache;
+
+    final SegmentIndexesSerde segmentIndexesSerde;
+    final ObjectFetcher objectFetcher;
+    final CaffeineStatsCounter statsCounter;
+    final Executor executor;
+    final AesEncryptionProvider encryptionProvider;
+
+    /**
+     * @param maxCacheSize   the max cache size (in items) or empty if the cache is unbounded.
+     * @param cacheRetention the retention time of items in the cache or empty if infinite retention.
+     */
+    public SegmentIndexesProvider(final Optional<Long> maxCacheSize,
+                                  final Optional<Duration> cacheRetention,
+                                  final ObjectFetcher objectFetcher,
+                                  final AesEncryptionProvider encryptionProvider,
+                                  final Executor executor) {
+        statsCounter = new CaffeineStatsCounter(SEGMENT_MANIFEST_METRIC_GROUP_NAME);
+        segmentIndexesSerde = new SegmentIndexesSerde();
+        this.encryptionProvider = encryptionProvider;
+        this.objectFetcher = objectFetcher;
+        this.executor = executor;
+        final var cacheBuilder = Caffeine.newBuilder()
+            .recordStats(() -> statsCounter)
+            .executor(executor);
+        maxCacheSize.ifPresent(cacheBuilder::maximumSize);
+        cacheRetention.ifPresent(cacheBuilder::expireAfterWrite);
+        this.cache = cacheBuilder.buildAsync(key -> {
+            try (final InputStream is = objectFetcher.fetch(key)) {
+
+                return segmentIndexesSerde.deserialize(is.readAllBytes());
+            }
+        });
+        statsCounter.registerSizeMetric(cache.synchronous()::estimatedSize);
+    }
+
+    public NavigableMap<Integer, Object> get(final SegmentManifest segmentManifest,
+                                             final ObjectKey indexesKey)
+        throws StorageBackendException, IOException {
+        try {
+            return cache.asMap()
+                .compute(indexesKey, (key, val) -> CompletableFuture.supplyAsync(() -> {
+                    if (val == null) {
+                        statsCounter.recordMiss();
+                        try {
+                            return fetch(segmentManifest, key);
+                        } catch (final StorageBackendException e) {
+                            throw new CompletionException(e);
+                        }
+                    } else {
+                        statsCounter.recordHit();
+                        try {
+                            return val.get();
+                        } catch (final InterruptedException | ExecutionException e) {
+                            throw new CompletionException(e);
+                        }
+                    }
+                }, executor))
+                .get(GET_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (final ExecutionException e) {
+            // Unwrap previously wrapped exceptions if possible.
+            final Throwable cause = e.getCause();
+
+            // We don't really expect this case, but handle it nevertheless.
+            if (cause == null) {
+                throw new RuntimeException(e);
+            }
+            if (e.getCause() instanceof StorageBackendException) {
+                throw (StorageBackendException) e.getCause();
+            }
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+
+            throw new RuntimeException(e);
+        } catch (final InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    NavigableMap<Integer, Object> fetch(final SegmentManifest segmentManifest,
+                                        final ObjectKey objectKey) throws StorageBackendException {
+        final var content = objectFetcher.fetch(objectKey);
+        DetransformChunkEnumeration detransformEnum = new BaseDetransformChunkEnumeration(content);
+        final Optional<SegmentEncryptionMetadata> encryptionMetadata = segmentManifest.encryption();
+        if (encryptionMetadata.isPresent()) {
+            detransformEnum = new DecryptionChunkEnumeration(
+                detransformEnum,
+                encryptionMetadata.get().ivSize(),
+                encryptedChunk -> encryptionProvider.decryptionCipher(encryptedChunk, encryptionMetadata.get())
+            );
+        }
+        final DetransformFinisher detransformFinisher = new DetransformFinisher(detransformEnum);
+        try (final var inputStream = detransformFinisher.toInputStream()) {
+            return segmentIndexesSerde.deserialize(inputStream.readAllBytes());
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/index/SegmentIndexesSerde.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/index/SegmentIndexesSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.index;
+
+import java.nio.ByteBuffer;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import org.apache.kafka.common.protocol.types.Struct;
+
+import static io.aiven.kafka.tieredstorage.index.SegmentIndex.SEGMENT_INDEXES_SCHEMA;
+import static io.aiven.kafka.tieredstorage.index.SegmentIndex.TAGGED_FIELD_NAME;
+
+public class SegmentIndexesSerde {
+
+    public byte[] serialize(final NavigableMap<Integer, Object> data) {
+        if (data.isEmpty()) {
+            return new byte[]{};
+        }
+
+        final var struct = new Struct(SEGMENT_INDEXES_SCHEMA);
+        struct.set(TAGGED_FIELD_NAME, data);
+
+        final var buf = ByteBuffer.allocate(struct.sizeOf());
+        struct.writeTo(buf);
+        return buf.array();
+    }
+
+    public NavigableMap<Integer, Object> deserialize(final byte[] data) {
+        if (data == null || data.length == 0) {
+            return new TreeMap<>();
+        }
+
+        final var buf = ByteBuffer.wrap(data);
+        final var struct = SEGMENT_INDEXES_SCHEMA.read(buf);
+
+        @SuppressWarnings("unchecked") final var fields =
+            (NavigableMap<Integer, Object>) struct.get(TAGGED_FIELD_NAME);
+        return fields;
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/ObjectKeyFactoryTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/ObjectKeyFactoryTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
-import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
 
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 
@@ -47,27 +46,10 @@ class ObjectKeyFactoryTest {
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value())
+        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value())
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-            .value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
+                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.indexes");
         assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value())
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
@@ -84,31 +66,11 @@ class ObjectKeyFactoryTest {
             "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                 + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
         ).isEqualTo(
             "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
+                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.indexes");
+
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo(
@@ -126,31 +88,10 @@ class ObjectKeyFactoryTest {
             "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                 + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
         ).isEqualTo(
             "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
+                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo(
@@ -166,21 +107,8 @@ class ObjectKeyFactoryTest {
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LOG).value()
         ).isEqualTo("prefix/topic/7/file.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
-        ).isEqualTo("prefix/topic/7/file.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo("prefix/topic/7/file.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo("prefix/topic/7/file.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo("prefix/topic/7/file.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo("prefix/topic/7/file.leader-epoch-checkpoint");
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
+        ).isEqualTo("prefix/topic/7/file.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo("prefix/topic/7/file.rsm-manifest");
@@ -196,21 +124,8 @@ class ObjectKeyFactoryTest {
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LOG).value()
         ).isEqualTo("other/topic/7/file.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
-        ).isEqualTo("other/topic/7/file.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo("other/topic/7/file.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo("other/topic/7/file.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo("other/topic/7/file.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo("other/topic/7/file.leader-epoch-checkpoint");
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
+        ).isEqualTo("other/topic/7/file.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo("other/topic/7/file.rsm-manifest");
@@ -222,30 +137,6 @@ class ObjectKeyFactoryTest {
         assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LOG).value())
             .isEqualTo(
                 "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
-    }
-
-    @Test
-    void suffixForIndexTypes() {
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.OFFSET))
-            .isEqualTo(ObjectKeyFactory.Suffix.OFFSET_INDEX)
-            .extracting("value")
-            .isEqualTo("index");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.TIMESTAMP))
-            .isEqualTo(ObjectKeyFactory.Suffix.TIME_INDEX)
-            .extracting("value")
-            .isEqualTo("timeindex");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT))
-            .isEqualTo(ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT)
-            .extracting("value")
-            .isEqualTo("snapshot");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.TRANSACTION))
-            .isEqualTo(ObjectKeyFactory.Suffix.TXN_INDEX)
-            .extracting("value")
-            .isEqualTo("txnindex");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.LEADER_EPOCH))
-            .isEqualTo(ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-            .extracting("value")
-            .isEqualTo("leader-epoch-checkpoint");
     }
 
     @Test

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -134,43 +134,27 @@ class RemoteStorageManagerMetricsTest {
             .isEqualTo(0.0);
 
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-total"))
-            .isEqualTo(18.0);
+            .isEqualTo(9.0);
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-rate"))
-            .isEqualTo(18.0 / METRIC_TIME_WINDOW_SEC);
+            .isEqualTo(9.0 / METRIC_TIME_WINDOW_SEC);
 
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-bytes-total"))
-            .isEqualTo(1575.0);
+            .isEqualTo(1603.0);
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-bytes-rate"))
-            .isEqualTo(1575.0 / METRIC_TIME_WINDOW_SEC);
+            .isEqualTo(1603.0 / METRIC_TIME_WINDOW_SEC);
 
         for (final var suffix : ObjectKeyFactory.Suffix.values()) {
             final ObjectName storageMetricsName = ObjectName.getInstance(objectName + ",object-type=" + suffix.value);
-            switch (suffix) {
-                case TXN_INDEX:
-                    break;
-                case MANIFEST:
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-rate"))
-                        .isEqualTo(3.0 / METRIC_TIME_WINDOW_SEC);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-total"))
-                        .isEqualTo(3.0);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-rate"))
-                        .asInstanceOf(DOUBLE)
-                        .isGreaterThan(0.0);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-total"))
-                        .asInstanceOf(DOUBLE)
-                        .isGreaterThan(0.0);
-                    break;
-                default:
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-rate"))
-                        .isEqualTo(3.0 / METRIC_TIME_WINDOW_SEC);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-total"))
-                        .isEqualTo(3.0);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-rate"))
-                        .isEqualTo(30.0 / METRIC_TIME_WINDOW_SEC);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-total"))
-                        .isEqualTo(30.0);
-                    break;
-            }
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-rate"))
+                .isEqualTo(3.0 / METRIC_TIME_WINDOW_SEC);
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-total"))
+                .isEqualTo(3.0);
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-rate"))
+                .asInstanceOf(DOUBLE)
+                .isGreaterThan(0.0);
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-total"))
+                .asInstanceOf(DOUBLE)
+                .isGreaterThan(0.0);
         }
 
         // fetch related metrics

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -250,8 +250,7 @@ abstract class SingleBrokerTest {
                 assertThat(segmentFiles).containsKey(key);
                 assertThat(segmentFiles.get(key).stream()
                     .map(SingleBrokerTest::extractSuffix))
-                    .containsExactlyInAnyOrder(
-                        "index", "leader-epoch-checkpoint", "log", "rsm-manifest", "snapshot", "timeindex");
+                    .containsExactlyInAnyOrder("indexes", "log", "rsm-manifest");
             }
         }
 


### PR DESCRIPTION
Includes usage of tagged fields to group indexes on the same map; Serialization/Deserialization; and Provider (caching).

Follows the same approaches as custom metadata for serialization/deserialization, and segment provider and chunk management for caching.
