### PR TITLE
feat: concat indexes in the same object

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -29,6 +29,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="Metrics.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="MetricCollector.java"/>
     <suppress checks="CyclomaticComplexity" files="MetricCollector.java"/>
+    <suppress checks="CyclomaticComplexity" files="SegmentIndexesV1Builder.java"/>
     <suppress checks="CyclomaticComplexity" files="SingleBrokerTest.java"/>
     <suppress checks="NPathComplexity" files="SingleBrokerTest.java"/>
     <suppress checks="JavaNCSSCheck" files="MetricsRegistry.java"/>

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/ObjectKeyFactory.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/ObjectKeyFactory.java
@@ -24,7 +24,6 @@ import java.util.function.BiFunction;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
-import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
 
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 
@@ -43,29 +42,13 @@ public final class ObjectKeyFactory {
      */
     public enum Suffix {
         LOG("log"),
-        OFFSET_INDEX("index"),
-        TIME_INDEX("timeindex"),
-        PRODUCER_SNAPSHOT("snapshot"),
-        TXN_INDEX("txnindex"),
-        LEADER_EPOCH_CHECKPOINT("leader-epoch-checkpoint"),
+        INDEXES("indexes"),
         MANIFEST("rsm-manifest");
 
         public final String value;
 
         Suffix(final String value) {
             this.value = value;
-        }
-
-        static Suffix fromIndexType(final RemoteStorageManager.IndexType indexType) {
-            switch (indexType) {
-                case OFFSET: return OFFSET_INDEX;
-                case TIMESTAMP: return TIME_INDEX;
-                case PRODUCER_SNAPSHOT: return PRODUCER_SNAPSHOT;
-                case TRANSACTION: return TXN_INDEX;
-                case LEADER_EPOCH: return LEADER_EPOCH_CHECKPOINT;
-                default:
-                    throw new IllegalArgumentException("Unknown index type " + indexType);
-            }
         }
     }
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndex.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndex.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest;
+
+import io.aiven.kafka.tieredstorage.storage.BytesRange;
+
+public interface SegmentIndex {
+
+    int position();
+
+    int size();
+
+    BytesRange range();
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexV1.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexV1.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest;
+
+import java.util.Objects;
+
+import io.aiven.kafka.tieredstorage.storage.BytesRange;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SegmentIndexV1 implements SegmentIndex {
+    private final int position;
+    private final int size;
+
+    @JsonCreator
+    public SegmentIndexV1(@JsonProperty(value = "position", required = true) final int position,
+                          @JsonProperty(value = "size", required = true) final int size) {
+        this.position = position;
+        this.size = size;
+    }
+
+    @Override
+    @JsonProperty("position")
+    public int position() {
+        return position;
+    }
+
+    @Override
+    @JsonProperty("size")
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public BytesRange range() {
+        return BytesRange.ofFromPositionAndSize(position, size);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SegmentIndexV1 that = (SegmentIndexV1) o;
+        return position == that.position && size == that.size;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(position, size);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentIndexV1{"
+            + "position=" + position
+            + ", size=" + size
+            + '}';
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexes.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexes.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest;
+
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
+
+public interface SegmentIndexes {
+    SegmentIndex offset();
+
+    SegmentIndex timestamp();
+
+    SegmentIndex producerSnapshot();
+
+    SegmentIndex leaderEpoch();
+
+    SegmentIndex transaction();
+
+    SegmentIndex segmentIndex(RemoteStorageManager.IndexType indexType);
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest;
+
+import java.util.Objects;
+
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SegmentIndexesV1 implements SegmentIndexes {
+
+    private final SegmentIndexV1 offset;
+    private final SegmentIndexV1 timestamp;
+    private final SegmentIndexV1 producerSnapshot;
+    private final SegmentIndexV1 leaderEpoch;
+    private final SegmentIndexV1 transaction;
+
+    @JsonCreator
+    public SegmentIndexesV1(
+        @JsonProperty(value = "offset", required = true) final SegmentIndexV1 offset,
+        @JsonProperty(value = "timestamp", required = true) final SegmentIndexV1 timestamp,
+        @JsonProperty(value = "producerSnapshot", required = true) final SegmentIndexV1 producerSnapshot,
+        @JsonProperty(value = "leaderEpoch", required = true) final SegmentIndexV1 leaderEpoch,
+        @JsonProperty(value = "transaction", required = true) final SegmentIndexV1 transaction
+    ) {
+        this.offset = Objects.requireNonNull(offset, "offset cannot be null");
+        this.timestamp = Objects.requireNonNull(timestamp, "timestamp cannot be null");
+        this.producerSnapshot = Objects.requireNonNull(producerSnapshot, "producerSnapshot cannot be null");
+        this.leaderEpoch = Objects.requireNonNull(leaderEpoch, "leaderEpoch cannot be null");
+        this.transaction = transaction;
+    }
+
+    public static SegmentIndexesV1Builder builder() {
+        return new SegmentIndexesV1Builder();
+    }
+
+    @Override
+    @JsonProperty("offset")
+    public SegmentIndex offset() {
+        return offset;
+    }
+
+    @Override
+    @JsonProperty("timestamp")
+    public SegmentIndex timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    @JsonProperty("producerSnapshot")
+    public SegmentIndex producerSnapshot() {
+        return producerSnapshot;
+    }
+
+    @Override
+    @JsonProperty("leaderEpoch")
+    public SegmentIndex leaderEpoch() {
+        return leaderEpoch;
+    }
+
+    @Override
+    @JsonProperty("transaction")
+    public SegmentIndex transaction() {
+        return transaction;
+    }
+
+    @Override
+    public SegmentIndex segmentIndex(final RemoteStorageManager.IndexType indexType) {
+        switch (indexType) {
+            case OFFSET:
+                return offset;
+            case TIMESTAMP:
+                return timestamp;
+            case PRODUCER_SNAPSHOT:
+                return producerSnapshot;
+            case LEADER_EPOCH:
+                return leaderEpoch;
+            case TRANSACTION:
+                return transaction;
+            default:
+                throw new IllegalArgumentException("Unknown index type");
+        }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SegmentIndexesV1 that = (SegmentIndexesV1) o;
+        return Objects.equals(offset, that.offset)
+            && Objects.equals(timestamp, that.timestamp)
+            && Objects.equals(producerSnapshot, that.producerSnapshot)
+            && Objects.equals(leaderEpoch, that.leaderEpoch)
+            && Objects.equals(transaction, that.transaction);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(offset, timestamp, producerSnapshot, leaderEpoch, transaction);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentIndexesV1{"
+            + "offset=" + offset
+            + ", timestamp=" + timestamp
+            + ", producerSnapshot=" + producerSnapshot
+            + ", leaderEpoch=" + leaderEpoch
+            + ", transaction=" + transaction
+            + '}';
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1Builder.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1Builder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
+
+public class SegmentIndexesV1Builder {
+    private final Map<IndexType, SegmentIndexV1> indexes = new HashMap<>(IndexType.values().length);
+    private int currentPosition = 0;
+
+    public SegmentIndexesV1Builder add(final IndexType indexType, final int size) {
+        if (indexes.containsKey(indexType)) {
+            throw new IllegalStateException("Index " + indexType + " is already added");
+        }
+        indexes.put(indexType, new SegmentIndexV1(currentPosition, size));
+        currentPosition += size;
+        return this;
+    }
+
+    public SegmentIndexesV1 build() {
+        if (indexes.size() < 4) {
+            throw new IllegalStateException("Not enough indexes have been added. At least 4 required");
+        }
+        if (indexes.size() == 4 && indexes.containsKey(IndexType.TRANSACTION)) {
+            throw new IllegalStateException("OFFSET, TIMESTAMP, PRODUCER_SNAPSHOT, "
+                + "and LEADER_EPOCH indexes are required");
+        }
+        return new SegmentIndexesV1(
+            indexes.get(IndexType.OFFSET),
+            indexes.get(IndexType.TIMESTAMP),
+            indexes.get(IndexType.PRODUCER_SNAPSHOT),
+            indexes.get(IndexType.LEADER_EPOCH),
+            indexes.get(IndexType.TRANSACTION)
+        );
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifest.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifest.java
@@ -37,6 +37,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public interface SegmentManifest {
     ChunkIndex chunkIndex();
 
+    SegmentIndexes segmentIndexes();
+
     boolean compression();
 
     Optional<SegmentEncryptionMetadata> encryption();

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SegmentManifestV1 implements SegmentManifest {
     private final ChunkIndex chunkIndex;
+    private final SegmentIndexesV1 segmentIndexes;
     private final boolean compression;
     private final SegmentEncryptionMetadataV1 encryption;
     private final RemoteLogSegmentMetadata remoteLogSegmentMetadata;
@@ -36,20 +37,24 @@ public class SegmentManifestV1 implements SegmentManifest {
     @JsonCreator
     public SegmentManifestV1(@JsonProperty(value = "chunkIndex", required = true)
                              final ChunkIndex chunkIndex,
+                             @JsonProperty(value = "segmentIndexes", required = true)
+                             final SegmentIndexesV1 segmentIndexes,
                              @JsonProperty(value = "compression", required = true)
                              final boolean compression,
                              @JsonProperty("encryption")
                              final SegmentEncryptionMetadataV1 encryption) {
-        this(chunkIndex, compression, encryption, null);
+        this(chunkIndex, segmentIndexes, compression, encryption, null);
     }
 
     public SegmentManifestV1(final ChunkIndex chunkIndex,
+                             final SegmentIndexesV1 segmentIndexes,
                              final boolean compression,
                              final SegmentEncryptionMetadataV1 encryption,
                              final RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
         this.chunkIndex = Objects.requireNonNull(chunkIndex, "chunkIndex cannot be null");
-        this.compression = compression;
+        this.segmentIndexes = Objects.requireNonNull(segmentIndexes, "segmentIndexes cannot be null");
 
+        this.compression = compression;
         this.encryption = encryption;
 
         this.remoteLogSegmentMetadata = remoteLogSegmentMetadata;
@@ -59,6 +64,12 @@ public class SegmentManifestV1 implements SegmentManifest {
     @JsonProperty("chunkIndex")
     public ChunkIndex chunkIndex() {
         return chunkIndex;
+    }
+
+    @Override
+    @JsonProperty("segmentIndexes")
+    public SegmentIndexes segmentIndexes() {
+        return segmentIndexes;
     }
 
     @Override
@@ -115,6 +126,7 @@ public class SegmentManifestV1 implements SegmentManifest {
     public String toString() {
         return "SegmentManifestV1("
             + "chunkIndex=" + chunkIndex
+            + ", segmentIndexes=" + segmentIndexes
             + ", compression=" + compression
             + ", encryption=" + encryption
             + ")";

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/ObjectKeyFactoryTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/ObjectKeyFactoryTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
-import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
 
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 
@@ -47,27 +46,10 @@ class ObjectKeyFactoryTest {
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value())
+        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value())
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-            .value())
-            .isEqualTo(
-                "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
+                    + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.indexes");
         assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value())
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
@@ -84,31 +66,10 @@ class ObjectKeyFactoryTest {
             "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                 + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
         ).isEqualTo(
             "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo(
-            "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
+                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo(
@@ -126,31 +87,10 @@ class ObjectKeyFactoryTest {
             "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                 + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
         ).isEqualTo(
             "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo(
-            "other/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
-                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
+                + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo(
@@ -166,21 +106,8 @@ class ObjectKeyFactoryTest {
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LOG).value()
         ).isEqualTo("prefix/topic/7/file.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
-        ).isEqualTo("prefix/topic/7/file.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo("prefix/topic/7/file.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo("prefix/topic/7/file.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo("prefix/topic/7/file.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo("prefix/topic/7/file.leader-epoch-checkpoint");
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
+        ).isEqualTo("prefix/topic/7/file.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo("prefix/topic/7/file.rsm-manifest");
@@ -196,21 +123,8 @@ class ObjectKeyFactoryTest {
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LOG).value()
         ).isEqualTo("other/topic/7/file.log");
         assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.OFFSET_INDEX).value()
-        ).isEqualTo("other/topic/7/file.index");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TIME_INDEX).value()
-        ).isEqualTo("other/topic/7/file.timeindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT).value()
-        ).isEqualTo("other/topic/7/file.snapshot");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.TXN_INDEX).value()
-        ).isEqualTo("other/topic/7/file.txnindex");
-        assertThat(
-            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-                .value()
-        ).isEqualTo("other/topic/7/file.leader-epoch-checkpoint");
+            objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.INDEXES).value()
+        ).isEqualTo("other/topic/7/file.indexes");
         assertThat(
             objectKeyFactory.key(fields, REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.MANIFEST).value()
         ).isEqualTo("other/topic/7/file.rsm-manifest");
@@ -222,30 +136,6 @@ class ObjectKeyFactoryTest {
         assertThat(objectKeyFactory.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKeyFactory.Suffix.LOG).value())
             .isEqualTo(
                 "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
-    }
-
-    @Test
-    void suffixForIndexTypes() {
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.OFFSET))
-            .isEqualTo(ObjectKeyFactory.Suffix.OFFSET_INDEX)
-            .extracting("value")
-            .isEqualTo("index");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.TIMESTAMP))
-            .isEqualTo(ObjectKeyFactory.Suffix.TIME_INDEX)
-            .extracting("value")
-            .isEqualTo("timeindex");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT))
-            .isEqualTo(ObjectKeyFactory.Suffix.PRODUCER_SNAPSHOT)
-            .extracting("value")
-            .isEqualTo("snapshot");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.TRANSACTION))
-            .isEqualTo(ObjectKeyFactory.Suffix.TXN_INDEX)
-            .extracting("value")
-            .isEqualTo("txnindex");
-        assertThat(ObjectKeyFactory.Suffix.fromIndexType(RemoteStorageManager.IndexType.LEADER_EPOCH))
-            .isEqualTo(ObjectKeyFactory.Suffix.LEADER_EPOCH_CHECKPOINT)
-            .extracting("value")
-            .isEqualTo("leader-epoch-checkpoint");
     }
 
     @Test

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -134,43 +134,27 @@ class RemoteStorageManagerMetricsTest {
             .isEqualTo(0.0);
 
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-total"))
-            .isEqualTo(18.0);
+            .isEqualTo(9.0);
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-rate"))
-            .isEqualTo(18.0 / METRIC_TIME_WINDOW_SEC);
+            .isEqualTo(9.0 / METRIC_TIME_WINDOW_SEC);
 
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-bytes-total"))
-            .isEqualTo(1575.0);
+            .isEqualTo(2160.0);
         assertThat(MBEAN_SERVER.getAttribute(metricName, "object-upload-bytes-rate"))
-            .isEqualTo(1575.0 / METRIC_TIME_WINDOW_SEC);
+            .isEqualTo(2160.0 / METRIC_TIME_WINDOW_SEC);
 
         for (final var suffix : ObjectKeyFactory.Suffix.values()) {
             final ObjectName storageMetricsName = ObjectName.getInstance(objectName + ",object-type=" + suffix.value);
-            switch (suffix) {
-                case TXN_INDEX:
-                    break;
-                case MANIFEST:
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-rate"))
-                        .isEqualTo(3.0 / METRIC_TIME_WINDOW_SEC);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-total"))
-                        .isEqualTo(3.0);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-rate"))
-                        .asInstanceOf(DOUBLE)
-                        .isGreaterThan(0.0);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-total"))
-                        .asInstanceOf(DOUBLE)
-                        .isGreaterThan(0.0);
-                    break;
-                default:
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-rate"))
-                        .isEqualTo(3.0 / METRIC_TIME_WINDOW_SEC);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-total"))
-                        .isEqualTo(3.0);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-rate"))
-                        .isEqualTo(30.0 / METRIC_TIME_WINDOW_SEC);
-                    assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-total"))
-                        .isEqualTo(30.0);
-                    break;
-            }
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-rate"))
+                .isEqualTo(3.0 / METRIC_TIME_WINDOW_SEC);
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-total"))
+                .isEqualTo(3.0);
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-rate"))
+                .asInstanceOf(DOUBLE)
+                .isGreaterThan(0.0);
+            assertThat(MBEAN_SERVER.getAttribute(storageMetricsName, "object-upload-bytes-total"))
+                .asInstanceOf(DOUBLE)
+                .isGreaterThan(0.0);
         }
 
         // fetch related metrics

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/ChunkCacheTest.java
@@ -23,8 +23,11 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
+
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
@@ -65,8 +68,16 @@ class ChunkCacheTest {
     private static final byte[] CHUNK_0 = "0123456789".getBytes();
     private static final byte[] CHUNK_1 = "1011121314".getBytes();
     private static final FixedSizeChunkIndex FIXED_SIZE_CHUNK_INDEX = new FixedSizeChunkIndex(10, 10, 10, 10);
+    private static final SegmentIndexesV1 SEGMENT_INDEXES = SegmentIndexesV1.builder()
+        .add(IndexType.OFFSET, 1)
+        .add(IndexType.TIMESTAMP, 1)
+        .add(IndexType.PRODUCER_SNAPSHOT, 1)
+        .add(IndexType.LEADER_EPOCH, 1)
+        .add(IndexType.TRANSACTION, 1)
+        .build();
+
     private static final SegmentManifest SEGMENT_MANIFEST =
-        new SegmentManifestV1(FIXED_SIZE_CHUNK_INDEX, false, null, null);
+        new SegmentManifestV1(FIXED_SIZE_CHUNK_INDEX, SEGMENT_INDEXES, false, null, null);
     private static final String TEST_EXCEPTION_MESSAGE = "test_message";
     private static final String SEGMENT_KEY = "topic/segment";
     private static final ObjectKey SEGMENT_OBJECT_KEY = () -> SEGMENT_KEY;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1BuilderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1BuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.manifest;
+
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SegmentIndexesV1BuilderTest {
+
+    @Test
+    void shouldFailWhenBuildingWithoutIndexes() {
+        assertThatThrownBy(() -> new SegmentIndexesV1Builder().build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Not enough indexes have been added. At least 4 required");
+    }
+
+    @Test
+    void shouldFailWhenBuildingWithNotEnoughIndexes() {
+        assertThatThrownBy(() -> new SegmentIndexesV1Builder()
+            .add(RemoteStorageManager.IndexType.OFFSET, 1)
+            .add(RemoteStorageManager.IndexType.TIMESTAMP, 1)
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Not enough indexes have been added. At least 4 required");
+    }
+
+    @Test
+    void shouldFailWhenAddingIndexManyTimes() {
+        assertThatThrownBy(() -> new SegmentIndexesV1Builder()
+            .add(RemoteStorageManager.IndexType.OFFSET, 1)
+            .add(RemoteStorageManager.IndexType.OFFSET, 1)
+            .build())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Index OFFSET is already added");
+    }
+
+    @Test
+    void shouldBuildIndexesWithTransaction() {
+        final var indexes = new SegmentIndexesV1Builder()
+            .add(RemoteStorageManager.IndexType.OFFSET, 1)
+            .add(RemoteStorageManager.IndexType.TIMESTAMP, 1)
+            .add(RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT, 1)
+            .add(RemoteStorageManager.IndexType.LEADER_EPOCH, 1)
+            .add(RemoteStorageManager.IndexType.TRANSACTION, 1)
+            .build();
+        assertThat(indexes.offset()).isEqualTo(new SegmentIndexV1(0, 1));
+        assertThat(indexes.timestamp()).isEqualTo(new SegmentIndexV1(1, 1));
+        assertThat(indexes.producerSnapshot()).isEqualTo(new SegmentIndexV1(2, 1));
+        assertThat(indexes.leaderEpoch()).isEqualTo(new SegmentIndexV1(3, 1));
+        assertThat(indexes.transaction()).isEqualTo(new SegmentIndexV1(4, 1));
+    }
+
+    @Test
+    void shouldBuildIndexesWithoutTransaction() {
+        final var indexes = new SegmentIndexesV1Builder()
+            .add(RemoteStorageManager.IndexType.OFFSET, 1)
+            .add(RemoteStorageManager.IndexType.TIMESTAMP, 1)
+            .add(RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT, 1)
+            .add(RemoteStorageManager.IndexType.LEADER_EPOCH, 1)
+            .build();
+        assertThat(indexes.offset()).isEqualTo(new SegmentIndexV1(0, 1));
+        assertThat(indexes.timestamp()).isEqualTo(new SegmentIndexV1(1, 1));
+        assertThat(indexes.producerSnapshot()).isEqualTo(new SegmentIndexV1(2, 1));
+        assertThat(indexes.leaderEpoch()).isEqualTo(new SegmentIndexV1(3, 1));
+        assertThat(indexes.transaction()).isNull();
+    }
+
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationSourceInputStreamClosingTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationSourceInputStreamClosingTest.java
@@ -24,10 +24,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
+
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
 import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManagerFactory;
 import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
 import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
@@ -62,8 +65,15 @@ class FetchChunkEnumerationSourceInputStreamClosingTest {
 
     static final FixedSizeChunkIndex CHUNK_INDEX = new FixedSizeChunkIndex(
         CHUNK_SIZE, CHUNK_SIZE * 3, CHUNK_SIZE, CHUNK_SIZE);
+    static final SegmentIndexesV1 SEGMENT_INDEXES = SegmentIndexesV1.builder()
+        .add(IndexType.OFFSET, 1)
+        .add(IndexType.TIMESTAMP, 1)
+        .add(IndexType.PRODUCER_SNAPSHOT, 1)
+        .add(IndexType.LEADER_EPOCH, 1)
+        .add(IndexType.TRANSACTION, 1)
+        .build();
     static final SegmentManifest SEGMENT_MANIFEST = new SegmentManifestV1(
-        CHUNK_INDEX, false, null, null);
+        CHUNK_INDEX, SEGMENT_INDEXES, false, null, null);
 
     TestObjectFetcher fetcher;
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
@@ -19,7 +19,10 @@ package io.aiven.kafka.tieredstorage.transform;
 import java.io.ByteArrayInputStream;
 import java.util.NoSuchElementException;
 
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
+
 import io.aiven.kafka.tieredstorage.chunkmanager.DefaultChunkManager;
+import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
@@ -43,7 +46,15 @@ class FetchChunkEnumerationTest {
     DefaultChunkManager chunkManager;
 
     final FixedSizeChunkIndex chunkIndex = new FixedSizeChunkIndex(10, 100, 10, 100);
-    final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null, null);
+
+    final SegmentIndexesV1 segmentIndexesV1 = SegmentIndexesV1.builder()
+        .add(IndexType.OFFSET, 1)
+        .add(IndexType.TIMESTAMP, 1)
+        .add(IndexType.PRODUCER_SNAPSHOT, 1)
+        .add(IndexType.LEADER_EPOCH, 1)
+        .add(IndexType.TRANSACTION, 1)
+        .build();
+    final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, segmentIndexesV1, false, null, null);
 
     static final byte[] CHUNK_CONTENT = "0123456789".getBytes();
     static final ObjectKey SEGMENT_KEY = new TestObjectKey("topic/segment");
@@ -54,7 +65,7 @@ class FetchChunkEnumerationTest {
     @Test
     void failsWhenLargerStartPosition() {
         // Given
-        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, false, null, null);
+        final SegmentManifest manifest = new SegmentManifestV1(chunkIndex, segmentIndexesV1, false, null, null);
         // When
         final int from = 1000;
         final int to = from + 1;

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -250,8 +250,7 @@ abstract class SingleBrokerTest {
                 assertThat(segmentFiles).containsKey(key);
                 assertThat(segmentFiles.get(key).stream()
                     .map(SingleBrokerTest::extractSuffix))
-                    .containsExactlyInAnyOrder(
-                        "index", "leader-epoch-checkpoint", "log", "rsm-manifest", "snapshot", "timeindex");
+                    .containsExactlyInAnyOrder("indexes", "log", "rsm-manifest");
             }
         }
 


### PR DESCRIPTION
By having indexes together, the number of objects stored in remote tier got reduced from 4 or 5 to 1. Range fetch used to get specific indexes.
