### PR TITLE
Use disk-based cache in E2E tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,3 +48,5 @@ ENV KAFKA_OPTS="-javaagent:/opt/prometheus/jmx-exporter/jmx_prometheus_javaagent
 
 # Restore the user.
 USER appuser
+
+RUN mkdir /home/appuser/kafka-tiered-storage-cache

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -153,8 +153,9 @@ abstract class SingleBrokerTest {
             .withEnv("KAFKA_REMOTE_LOG_STORAGE_MANAGER_IMPL_PREFIX", "rsm.config.")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_SIZE", Integer.toString(CHUNK_SIZE))
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS",
-                "io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache")
+                "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE", "-1")
+            .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH", "/home/appuser/kafka-tiered-storage-cache")
             .withEnv("KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE", "REMOTE_SIZE")
             // other tweaks
             .withEnv("KAFKA_OPTS", "") // disable JMX exporter


### PR DESCRIPTION
The disk-based is more complex and also more realistic to be used in production.
