### PR TITLE
refactor: renaming module chunkmanager to fetch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ rsm.config.storage.gcs.credentials.default=true
 # The prefix can be skipped:
 #rsm.config.storage.key.prefix: "some/prefix/"
 
-# ----- Configure the chunk cache -----
+# ----- Configure the fetch chunk cache -----
 
-rsm.config.chunk.cache.class=io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache
-rsm.config.chunk.cache.path=/cache/root/directory
+rsm.config.fetch.chunk.cache.class=io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache
+rsm.config.fetch.chunk.cache.path=/cache/root/directory
 # Pick some cache size, 16 GiB here:
-rsm.config.chunk.cache.size=17179869184
+rsm.config.fetch.chunk.cache.size=17179869184
 # Prefetching size, 16 MiB here:
-rsm.config.chunk.cache.prefetch.max.size=16777216
+rsm.config.fetch.chunk.cache.prefetch.max.size=16777216
 ```
 
 You may want to tweak `remote.log.manager.task.interval.ms` and `log.retention.check.interval.ms` to see the tiered storage effects faster. However, you probably don't need to change this in production setups.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ rsm.config.storage.gcs.credentials.default=true
 
 # ----- Configure the chunk cache -----
 
-rsm.config.chunk.cache.class=io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache
+rsm.config.chunk.cache.class=io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache
 rsm.config.chunk.cache.path=/cache/root/directory
 # Pick some cache size, 16 GiB here:
 rsm.config.chunk.cache.size=17179869184

--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -54,8 +54,8 @@ import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundExceptio
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadataV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1Builder;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;

--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -54,6 +54,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundExceptio
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
+import io.aiven.kafka.tieredstorage.fetch.KeyNotFoundRuntimeException;
 import io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache;
 import io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadataV1;
@@ -68,7 +69,6 @@ import io.aiven.kafka.tieredstorage.security.DataKeyAndAAD;
 import io.aiven.kafka.tieredstorage.security.EncryptedDataKey;
 import io.aiven.kafka.tieredstorage.security.RsaEncryptionProvider;
 import io.aiven.kafka.tieredstorage.storage.KeyNotFoundException;
-import io.aiven.kafka.tieredstorage.transform.KeyNotFoundRuntimeException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -206,9 +206,9 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
             "storage.root", targetDir.toString(),
             "compression.enabled", Boolean.toString(compression),
             "encryption.enabled", Boolean.toString(encryption),
-            "chunk.cache.class", cacheClass,
-            "chunk.cache.path", cacheDir.toString(),
-            "chunk.cache.size", Integer.toString(100 * 1024 * 1024),
+            "fetch.chunk.cache.class", cacheClass,
+            "fetch.chunk.cache.path", cacheDir.toString(),
+            "fetch.chunk.cache.size", Integer.toString(100 * 1024 * 1024),
             "custom.metadata.fields.include", "REMOTE_SIZE,OBJECT_PREFIX,OBJECT_KEY"
         ));
         if (encryption) {
@@ -453,9 +453,9 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
                 put("storage.root", targetDir.toString());
                 put("compression.enabled", "true");
                 put("compression.heuristic.enabled", "true");
-                put("chunk.cache.size", 10000);
-                put("chunk.cache.class", InMemoryChunkCache.class.getCanonicalName());
-                put("chunk.cache.retention.ms", 10000);
+                put("fetch.chunk.cache.size", 10000);
+                put("fetch.chunk.cache.class", InMemoryChunkCache.class.getCanonicalName());
+                put("fetch.chunk.cache.retention.ms", 10000);
             }};
 
         rsm.configure(config);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -49,6 +49,8 @@ import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import io.aiven.kafka.tieredstorage.config.RemoteStorageManagerConfig;
 import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.fetch.ChunkManagerFactory;
+import io.aiven.kafka.tieredstorage.fetch.FetchChunkEnumeration;
+import io.aiven.kafka.tieredstorage.fetch.KeyNotFoundRuntimeException;
 import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadata;
 import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadataV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
@@ -82,8 +84,6 @@ import io.aiven.kafka.tieredstorage.transform.DecryptionChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.DetransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.DetransformFinisher;
 import io.aiven.kafka.tieredstorage.transform.EncryptionChunkEnumeration;
-import io.aiven.kafka.tieredstorage.transform.FetchChunkEnumeration;
-import io.aiven.kafka.tieredstorage.transform.KeyNotFoundRuntimeException;
 import io.aiven.kafka.tieredstorage.transform.TransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.TransformFinisher;
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -46,9 +46,9 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata.Custo
 import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundException;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManagerFactory;
 import io.aiven.kafka.tieredstorage.config.RemoteStorageManagerConfig;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManagerFactory;
 import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadata;
 import io.aiven.kafka.tieredstorage.manifest.SegmentEncryptionMetadataV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkKey.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkKey.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.nio.file.Path;
 import java.util.Objects;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactory.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactory.java
@@ -41,7 +41,7 @@ public class ChunkManagerFactory implements Configurable {
                     .cacheClass()
                     .getDeclaredConstructor(ChunkManager.class)
                     .newInstance(defaultChunkManager);
-                chunkCache.configure(config.originalsWithPrefix(ChunkManagerFactoryConfig.CHUNK_CACHE_PREFIX));
+                chunkCache.configure(config.originalsWithPrefix(ChunkManagerFactoryConfig.FETCH_CHUNK_CACHE_PREFIX));
                 return chunkCache;
             } catch (final ReflectiveOperationException e) {
                 throw new RuntimeException(e);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactory.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactory.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.util.Map;
 
 import org.apache.kafka.common.Configurable;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.ChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
 import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
 import io.aiven.kafka.tieredstorage.storage.ObjectFetcher;
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfig.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.util.Map;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.ChunkCache;
 import io.aiven.kafka.tieredstorage.config.validators.Subclass;
+import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
 
 public class ChunkManagerFactoryConfig extends AbstractConfig {
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfig.java
@@ -26,9 +26,9 @@ import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
 
 public class ChunkManagerFactoryConfig extends AbstractConfig {
 
-    protected static final String CHUNK_CACHE_PREFIX = "chunk.cache.";
-    public static final String CHUNK_CACHE_CONFIG = CHUNK_CACHE_PREFIX + "class";
-    private static final String CHUNK_CACHE_DOC = "The chunk cache implementation";
+    protected static final String FETCH_CHUNK_CACHE_PREFIX = "fetch.chunk.cache.";
+    public static final String FETCH_CHUNK_CACHE_CONFIG = FETCH_CHUNK_CACHE_PREFIX + "class";
+    private static final String FETCH_CHUNK_CACHE_DOC = "The fetch chunk cache implementation";
 
     private static final ConfigDef CONFIG;
 
@@ -36,12 +36,12 @@ public class ChunkManagerFactoryConfig extends AbstractConfig {
         CONFIG = new ConfigDef();
 
         CONFIG.define(
-            CHUNK_CACHE_CONFIG,
+            FETCH_CHUNK_CACHE_CONFIG,
             ConfigDef.Type.CLASS,
             null,
             Subclass.of(ChunkCache.class),
             ConfigDef.Importance.MEDIUM,
-            CHUNK_CACHE_DOC
+            FETCH_CHUNK_CACHE_DOC
         );
     }
 
@@ -51,6 +51,6 @@ public class ChunkManagerFactoryConfig extends AbstractConfig {
 
     @SuppressWarnings("unchecked")
     public Class<ChunkCache<?>> cacheClass() {
-        return (Class<ChunkCache<?>>) getClass(CHUNK_CACHE_CONFIG);
+        return (Class<ChunkCache<?>>) getClass(FETCH_CHUNK_CACHE_CONFIG);
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/DefaultChunkManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/DefaultChunkManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.io.InputStream;
 import java.util.List;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.transform;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +25,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import io.aiven.kafka.tieredstorage.Chunk;
-import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.storage.BytesRange;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/KeyNotFoundRuntimeException.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/KeyNotFoundRuntimeException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.transform;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import io.aiven.kafka.tieredstorage.storage.KeyNotFoundException;
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.common.Configurable;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter;
 import io.aiven.kafka.tieredstorage.storage.BytesRange;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.time.Duration;
 import java.util.Map;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCache.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,8 +24,8 @@ import java.util.Map;
 
 import org.apache.kafka.common.utils.Time;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Weigher;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheMetrics.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheMetrics.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.util.List;
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/InMemoryChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/InMemoryChunkCache.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Weigher;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumeration.java
@@ -25,7 +25,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import io.aiven.kafka.tieredstorage.Chunk;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.storage.BytesRange;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -94,9 +94,9 @@ class RemoteStorageManagerMetricsTest {
             "storage.backend.class",
             "io.aiven.kafka.tieredstorage.storage.filesystem.FileSystemStorage",
             "storage.root", target.toString(),
-            "chunk.cache.path", tmpDir.resolve("cache").toString(),
-            "chunk.cache.class", InMemoryChunkCache.class.getCanonicalName(),
-            "chunk.cache.size", 100 * 1024 * 1024,
+            "fetch.chunk.cache.path", tmpDir.resolve("cache").toString(),
+            "fetch.chunk.cache.class", InMemoryChunkCache.class.getCanonicalName(),
+            "fetch.chunk.cache.size", 100 * 1024 * 1024,
             "metrics.recording.level", "DEBUG"
         );
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -40,7 +40,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.storage.StorageBackendException;
 import io.aiven.kafka.tieredstorage.storage.filesystem.FileSystemStorage;
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkKeyTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkKeyTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import org.apache.kafka.common.Uuid;
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfigTest.java
@@ -33,9 +33,9 @@ class ChunkManagerFactoryConfigTest {
 
     @Test
     void invalidCacheClass() {
-        assertThatThrownBy(() -> new ChunkManagerFactoryConfig(Map.of("chunk.cache.class", "java.lang.Object")))
+        assertThatThrownBy(() -> new ChunkManagerFactoryConfig(Map.of("fetch.chunk.cache.class", "java.lang.Object")))
                 .isInstanceOf(ConfigException.class)
-                .hasMessage("chunk.cache.class should be a subclass of " + ChunkCache.class.getCanonicalName());
+                .hasMessage("fetch.chunk.cache.class should be a subclass of " + ChunkCache.class.getCanonicalName());
     }
 
     @ParameterizedTest
@@ -45,7 +45,7 @@ class ChunkManagerFactoryConfigTest {
     })
     void validCacheClass(final String cacheClass) {
         final ChunkManagerFactoryConfig config = new ChunkManagerFactoryConfig(
-                Map.of("chunk.cache.class", cacheClass)
+                Map.of("fetch.chunk.cache.class", cacheClass)
         );
         assertThat(config.cacheClass().getCanonicalName()).isEqualTo(cacheClass);
     }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryConfigTest.java
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigException;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.ChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,8 +40,8 @@ class ChunkManagerFactoryConfigTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-        "io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache",
-        "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache"
+        "io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache",
+        "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache"
     })
     void validCacheClass(final String cacheClass) {
         final ChunkManagerFactoryConfig config = new ChunkManagerFactoryConfig(

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryTest.java
@@ -61,9 +61,9 @@ class ChunkManagerFactoryTest {
     @MethodSource("cachingChunkManagers")
     void cachingChunkManagers(final Class<ChunkCache<?>> cls) {
         chunkManagerFactory.configure(Map.of(
-                "chunk.cache.class", cls,
-                "chunk.cache.size", 10,
-                "chunk.cache.retention.ms", 10,
+                "fetch.chunk.cache.class", cls,
+                "fetch.chunk.cache.size", 10,
+                "fetch.chunk.cache.retention.ms", 10,
                 "other.config.x", 10
             )
         );
@@ -80,7 +80,7 @@ class ChunkManagerFactoryTest {
 
     @Test
     void failedInitialization() {
-        chunkManagerFactory.configure(Map.of("chunk.cache.class", InMemoryChunkCache.class));
+        chunkManagerFactory.configure(Map.of("fetch.chunk.cache.class", InMemoryChunkCache.class));
         try (final MockedConstruction<?> ignored = mockConstruction(InMemoryChunkCache.class,
             (cachingChunkManager, context) -> {
                 throw new InvocationTargetException(null);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactoryTest.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.ChunkCache;
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/DefaultChunkManagerTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/DefaultChunkManagerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import javax.crypto.Cipher;
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumerationSourceInputStreamClosingTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumerationSourceInputStreamClosingTest.java
@@ -114,8 +114,8 @@ class FetchChunkEnumerationSourceInputStreamClosingTest {
                 result.add(Arguments.of(
                     Named.of("with in-memory cache",
                         Map.of(
-                            "chunk.cache.class", InMemoryChunkCache.class.getCanonicalName(),
-                            "chunk.cache.size", "-1"
+                            "fetch.chunk.cache.class", InMemoryChunkCache.class.getCanonicalName(),
+                            "fetch.chunk.cache.size", "-1"
                         )
                     ),
                     readFully,
@@ -124,9 +124,9 @@ class FetchChunkEnumerationSourceInputStreamClosingTest {
                 result.add(Arguments.of(
                     Named.of("with disk-based cache",
                         Map.of(
-                            "chunk.cache.class", DiskBasedChunkCache.class.getCanonicalName(),
-                            "chunk.cache.path", Files.createTempDirectory("cache").toString(),
-                            "chunk.cache.size", "-1"
+                            "fetch.chunk.cache.class", DiskBasedChunkCache.class.getCanonicalName(),
+                            "fetch.chunk.cache.path", Files.createTempDirectory("cache").toString(),
+                            "fetch.chunk.cache.size", "-1"
                         )
                     ),
                     readFully,

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumerationSourceInputStreamClosingTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumerationSourceInputStreamClosingTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.transform;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,8 +26,6 @@ import java.util.Map;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
-import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
-import io.aiven.kafka.tieredstorage.fetch.ChunkManagerFactory;
 import io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache;
 import io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumerationTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumerationTest.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.transform;
+package io.aiven.kafka.tieredstorage.fetch;
 
 import java.io.ByteArrayInputStream;
 import java.util.NoSuchElementException;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
-import io.aiven.kafka.tieredstorage.fetch.DefaultChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheConfigTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.time.Duration;
 import java.util.Map;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheMetricsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheMetricsTest.java
@@ -92,7 +92,7 @@ class ChunkCacheMetricsTest {
     @MethodSource("caches")
     void shouldRecordMetrics(final Class<ChunkCache<?>> chunkCacheClass, final Map<String, ?> config)
         throws Exception {
-        // Given a chunk cache implementation
+        // Given a fetch chunk cache implementation
         when(chunkManager.getChunk(any(), any(), anyInt()))
             .thenReturn(new ByteArrayInputStream("test".getBytes()));
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -25,8 +25,8 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheConfigTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,8 +37,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCacheConfig.CACHE_DIRECTORY;
-import static io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCacheConfig.TEMP_CACHE_DIRECTORY;
+import static io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCacheConfig.CACHE_DIRECTORY;
+import static io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCacheConfig.TEMP_CACHE_DIRECTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheMetricsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -32,7 +32,7 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.DefaultChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.DefaultChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskBasedChunkCacheTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.chunkmanager.cache;
+package io.aiven.kafka.tieredstorage.fetch.cache;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,8 +22,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkKey;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.RemovalListener;
@@ -36,8 +36,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCacheConfig.CACHE_DIRECTORY;
-import static io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCacheConfig.TEMP_CACHE_DIRECTORY;
+import static io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCacheConfig.CACHE_DIRECTORY;
+import static io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCacheConfig.TEMP_CACHE_DIRECTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationSourceInputStreamClosingTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationSourceInputStreamClosingTest.java
@@ -26,10 +26,10 @@ import java.util.Map;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManager;
-import io.aiven.kafka.tieredstorage.chunkmanager.ChunkManagerFactory;
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache;
-import io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManagerFactory;
+import io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumerationTest.java
@@ -21,7 +21,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
-import io.aiven.kafka.tieredstorage.chunkmanager.DefaultChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.DefaultChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;

--- a/demo/README.md
+++ b/demo/README.md
@@ -49,8 +49,6 @@ make consume
 
 This scenario uses `S3Storage` with the real AWS S3 as the remote storage.
 
-Please note that the in-memory cache `io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache` is used in this scenario. This is necessary to mitigate a now-present bug in Kafka with slow and excessive read from S3.
-
 For this scenario you need to have:
 1. Valid AWS S3 credentials (e.g. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`).
 2. A test bucket.

--- a/demo/README.md
+++ b/demo/README.md
@@ -49,7 +49,7 @@ make consume
 
 This scenario uses `S3Storage` with the real AWS S3 as the remote storage.
 
-Please note that the in-memory cache `io.aiven.kafka.tieredstorage.chunkmanager.cache.InMemoryChunkCache` is used in this scenario. This is necessary to mitigate a now-present bug in Kafka with slow and excessive read from S3.
+Please note that the in-memory cache `io.aiven.kafka.tieredstorage.fetch.cache.InMemoryChunkCache` is used in this scenario. This is necessary to mitigate a now-present bug in Kafka with slow and excessive read from S3.
 
 For this scenario you need to have:
 1. Valid AWS S3 credentials (e.g. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`).

--- a/demo/compose-azure-blob-azurite.yml
+++ b/demo/compose-azure-blob-azurite.yml
@@ -58,7 +58,7 @@ services:
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH: "/tiered-storage-for-apache-kafka/core/*:/tiered-storage-for-apache-kafka/azure/*"
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_NAME: "io.aiven.kafka.tieredstorage.RemoteStorageManager"
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 4194304 # 4 MiB
-      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache"
+      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH: /home/appuser/kafka-tiered-storage-cache
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: 1073741824 # 1 GiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PREFETCH_MAX_SIZE: 16777216 # 16 MiB

--- a/demo/compose-gcs-fake-gcs-server.yml
+++ b/demo/compose-gcs-fake-gcs-server.yml
@@ -58,7 +58,7 @@ services:
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH: "/tiered-storage-for-apache-kafka/core/*:/tiered-storage-for-apache-kafka/gcs/*"
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_NAME: "io.aiven.kafka.tieredstorage.RemoteStorageManager"
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 4194304 # 4 MiB
-      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache"
+      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH: /home/appuser/kafka-tiered-storage-cache
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: 1073741824 # 1 GiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PREFETCH_MAX_SIZE: 16777216 # 16 MiB

--- a/demo/compose-local-fs.yml
+++ b/demo/compose-local-fs.yml
@@ -57,7 +57,7 @@ services:
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH: "/tiered-storage-for-apache-kafka/core/*"
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_NAME: "io.aiven.kafka.tieredstorage.RemoteStorageManager"
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 4194304 # 4 MiB
-      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache"
+      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH: /home/appuser/kafka-tiered-storage-cache
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: 1073741824 # 1 GiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PREFETCH_MAX_SIZE: 16777216 # 16 MiB

--- a/demo/compose-s3-aws.yml
+++ b/demo/compose-s3-aws.yml
@@ -57,7 +57,7 @@ services:
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH: "/tiered-storage-for-apache-kafka/core/*:/tiered-storage-for-apache-kafka/s3/*"
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_NAME: "io.aiven.kafka.tieredstorage.RemoteStorageManager"
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 4194304 # 4 MiB
-      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache"
+      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH: /home/appuser/kafka-tiered-storage-cache
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: 1073741824 # 1 GiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PREFETCH_MAX_SIZE: 16777216 # 16 MiB

--- a/demo/compose-s3-minio.yml
+++ b/demo/compose-s3-minio.yml
@@ -58,7 +58,7 @@ services:
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH: "/tiered-storage-for-apache-kafka/core/*:/tiered-storage-for-apache-kafka/s3/*"
       KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_NAME: "io.aiven.kafka.tieredstorage.RemoteStorageManager"
       KAFKA_RSM_CONFIG_CHUNK_SIZE: 4194304 # 4 MiB
-      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache"
+      KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS: "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache"
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH: /home/appuser/kafka-tiered-storage-cache
       KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE: 1073741824 # 1 GiB
       KAFKA_RSM_CONFIG_CHUNK_CACHE_PREFETCH_MAX_SIZE: 16777216 # 16 MiB

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -150,10 +150,10 @@ abstract class SingleBrokerTest {
             .withEnv("KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_NAME",
                 "io.aiven.kafka.tieredstorage.RemoteStorageManager")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_SIZE", Integer.toString(CHUNK_SIZE))
-            .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS",
+            .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_CLASS",
                 "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache")
-            .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE", "-1")
-            .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH", "/home/appuser/kafka-tiered-storage-cache")
+            .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_SIZE", "-1")
+            .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_PATH", "/home/appuser/kafka-tiered-storage-cache")
             .withEnv("KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE", "REMOTE_SIZE")
             // other tweaks
             .withEnv("KAFKA_OPTS", "") // disable JMX exporter

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -151,7 +151,7 @@ abstract class SingleBrokerTest {
                 "io.aiven.kafka.tieredstorage.RemoteStorageManager")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_SIZE", Integer.toString(CHUNK_SIZE))
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_CLASS",
-                "io.aiven.kafka.tieredstorage.chunkmanager.cache.DiskBasedChunkCache")
+                "io.aiven.kafka.tieredstorage.fetch.cache.DiskBasedChunkCache")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_SIZE", "-1")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_CACHE_PATH", "/home/appuser/kafka-tiered-storage-cache")
             .withEnv("KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE", "REMOTE_SIZE")


### PR DESCRIPTION
Now that purpose of `chunkmanager` module is more clear, we can rename it to `fetch` so it's explicit when it's used and regroup the components that belong to this module (specifically FetchChunkEnumeration that does not really belong in the `transform` module). 

Changes:
- Renaming module to `fetch`
- Moving FetchChunkEnumeration from `transform` into `fetch` module
- Renaming cache configuration with `fetch` prefix

See commits for details.