### PR TITLE
feat: return a known exception when remote fetch is interrupted

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -30,6 +30,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="Metrics.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="MetricCollector.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="AzureBlobStorage.java"/>
+    <suppress checks="CyclomaticComplexity" files="ChunkCache.java"/>
     <suppress checks="CyclomaticComplexity" files="MetricCollector.java"/>
     <suppress checks="CyclomaticComplexity" files="SegmentIndexesV1Builder.java"/>
     <suppress checks="CyclomaticComplexity" files="SingleBrokerTest.java"/>

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteFetchTimeoutException.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteFetchTimeoutException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage;
+
+public class RemoteFetchTimeoutException extends RuntimeException {
+    public RemoteFetchTimeoutException(final String message, final Throwable e) {
+        super(message, e);
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -454,6 +454,9 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             final var segmentKey = objectKey(remoteLogSegmentMetadata, suffix);
             return new FetchChunkEnumeration(chunkManager, segmentKey, segmentManifest, range)
                 .toInputStream();
+        } catch (final RemoteFetchTimeoutException e) {
+            log.warn("Remote fetch has been interrupted", e);
+            return InputStream.nullInputStream();
         } catch (final KeyNotFoundException | KeyNotFoundRuntimeException e) {
             throw new RemoteResourceNotFoundException(e);
         } catch (final Exception e) {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.common.Configurable;
 
+import io.aiven.kafka.tieredstorage.RemoteFetchTimeoutException;
 import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
 import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
@@ -117,10 +118,13 @@ public abstract class ChunkCache<T> implements ChunkManager, Configurable {
             if (e.getCause() instanceof IOException) {
                 throw (IOException) e.getCause();
             }
+            if (e.getCause() instanceof InterruptedException || e.getCause() instanceof TimeoutException) {
+                throw new RemoteFetchTimeoutException("Fetching chunk has been interrupted", e);
+            }
 
             throw new RuntimeException(e);
         } catch (final InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
+            throw new RemoteFetchTimeoutException("Fetching chunk has been interrupted", e);
         }
     }
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestProvider.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestProvider.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.aiven.kafka.tieredstorage.RemoteFetchTimeoutException;
 import io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter;
 import io.aiven.kafka.tieredstorage.storage.ObjectFetcher;
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
@@ -81,10 +82,13 @@ public class SegmentManifestProvider {
             if (e.getCause() instanceof IOException) {
                 throw (IOException) e.getCause();
             }
+            if (e.getCause() instanceof InterruptedException || e.getCause() instanceof TimeoutException) {
+                throw new RemoteFetchTimeoutException("Fetching segment manifest has been interrupted", e);
+            }
 
             throw new RuntimeException(e);
         } catch (final InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
+            throw new RemoteFetchTimeoutException("Fetching segment manifest has been interrupted", e);
         }
     }
 }


### PR DESCRIPTION
This new exception aims to identify interrupted remote fetch requests caused by small fetch.max.wait.ms configurations.
In the case of fetching logs, if it happens when caching a chunk or fetching a segment manifest, it will fail with an empty stream that will lead to a retry.
If it fails when fetching an index, then it's exception will be triggered, but instead of a generic RuntimeException, a RemoteFetchTimeoutException is thrown.