### PR TITLE
 fix: add empty indexes to builder 

### DIFF
--- a/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/integration-test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -501,6 +501,37 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
             segmentIndexBuilder
         );
         assertThat(is).isNotEmpty();
+        assertThat(segmentIndexBuilder.indexes()).containsOnly(IndexType.OFFSET);
+
+
+        // adding required indexes to test builder
+        rsm.transformIndex(
+            IndexType.TIMESTAMP,
+            new ByteArrayInputStream(bytes),
+            bytes.length,
+            encryptionMetadata,
+            segmentIndexBuilder
+        );
+        rsm.transformIndex(
+            IndexType.LEADER_EPOCH,
+            new ByteArrayInputStream(bytes),
+            bytes.length,
+            encryptionMetadata,
+            segmentIndexBuilder
+        );
+        rsm.transformIndex(
+            IndexType.PRODUCER_SNAPSHOT,
+            new ByteArrayInputStream(bytes),
+            bytes.length,
+            encryptionMetadata,
+            segmentIndexBuilder
+        );
+        final var index = segmentIndexBuilder.build();
+        assertThat(index.offset().size()).isGreaterThan(0);
+        assertThat(index.timestamp().size()).isGreaterThan(0);
+        assertThat(index.leaderEpoch().size()).isGreaterThan(0);
+        assertThat(index.producerSnapshot().size()).isGreaterThan(0);
+        assertThat(index.transaction()).isNull();
     }
 
     @ParameterizedTest
@@ -532,6 +563,36 @@ class RemoteStorageManagerTest extends RsaKeyAwareTest {
             segmentIndexBuilder
         );
         assertThat(is).isEmpty();
+        assertThat(segmentIndexBuilder.indexes()).containsOnly(IndexType.OFFSET);
+
+        // adding required indexes to test builder
+        rsm.transformIndex(
+            IndexType.TIMESTAMP,
+            InputStream.nullInputStream(),
+            0,
+            encryptionMetadata,
+            segmentIndexBuilder
+        );
+        rsm.transformIndex(
+            IndexType.LEADER_EPOCH,
+            InputStream.nullInputStream(),
+            0,
+            encryptionMetadata,
+            segmentIndexBuilder
+        );
+        rsm.transformIndex(
+            IndexType.PRODUCER_SNAPSHOT,
+            InputStream.nullInputStream(),
+            0,
+            encryptionMetadata,
+            segmentIndexBuilder
+        );
+        final var index = segmentIndexBuilder.build();
+        assertThat(index.offset().size()).isEqualTo(0);
+        assertThat(index.timestamp().size()).isEqualTo(0);
+        assertThat(index.leaderEpoch().size()).isEqualTo(0);
+        assertThat(index.producerSnapshot().size()).isEqualTo(0);
+        assertThat(index.transaction()).isNull();
     }
 
     @Test

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1Builder.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1Builder.java
@@ -16,7 +16,10 @@
 
 package io.aiven.kafka.tieredstorage.manifest;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
@@ -34,9 +37,17 @@ public class SegmentIndexesV1Builder {
         return this;
     }
 
+    // for testing and logging purposes
+    public List<IndexType> indexes() {
+        final var indexTypes = new ArrayList<>(indexes.keySet());
+        Collections.sort(indexTypes);
+        return indexTypes;
+    }
+
     public SegmentIndexesV1 build() {
         if (indexes.size() < 4) {
-            throw new IllegalStateException("Not enough indexes have been added. At least 4 required");
+            throw new IllegalStateException("Not enough indexes have been added; at least 4 required. "
+                + "Indexes included: " + indexes());
         }
         if (indexes.size() == 4 && indexes.containsKey(IndexType.TRANSACTION)) {
             throw new IllegalStateException("OFFSET, TIMESTAMP, PRODUCER_SNAPSHOT, "

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1BuilderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1BuilderTest.java
@@ -29,7 +29,7 @@ class SegmentIndexesV1BuilderTest {
     void shouldFailWhenBuildingWithoutIndexes() {
         assertThatThrownBy(() -> new SegmentIndexesV1Builder().build())
             .isInstanceOf(IllegalStateException.class)
-            .hasMessage("Not enough indexes have been added. At least 4 required");
+            .hasMessage("Not enough indexes have been added; at least 4 required. Indexes included: []");
     }
 
     @Test
@@ -39,7 +39,8 @@ class SegmentIndexesV1BuilderTest {
             .add(RemoteStorageManager.IndexType.TIMESTAMP, 1)
             .build())
             .isInstanceOf(IllegalStateException.class)
-            .hasMessage("Not enough indexes have been added. At least 4 required");
+            .hasMessage("Not enough indexes have been added; at least 4 required. "
+                + "Indexes included: [OFFSET, TIMESTAMP]");
     }
 
     @Test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ##
-FROM docker.io/aivenoy/kafka:3.6.1-rc0-2023-11-24
+FROM docker.io/aivenoy/kafka:3.6.1-2023-12-05
 
 ARG _VERSION
 


### PR DESCRIPTION
By ignoring empty indexes--that is a valid case when segment sizes are too small; even if not recommended--the requirement to have at least 4 indexes when uploaded was not met.

This fix improves the logging to show what indexes are included therefore know which one is missing; and includes a fix to add empty indexes to the builder.

See commits for more details. It includes moving some RSM tests from IT to unit tests.