### PR TITLE
feat: extend BytesRange to support empty ranges

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -520,6 +520,9 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             if (segmentIndex == null) {
                 throw new RemoteResourceNotFoundException("Index " + indexType + " not found on " + key);
             }
+            if (segmentIndex.range().size() == 0) {
+                return InputStream.nullInputStream();
+            }
             return segmentIndexesCache.get(
                 key,
                 indexType,

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -520,7 +520,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             if (segmentIndex == null) {
                 throw new RemoteResourceNotFoundException("Index " + indexType + " not found on " + key);
             }
-            if (segmentIndex.range().size() == 0) {
+            if (segmentIndex.range().isEmpty()) {
                 return InputStream.nullInputStream();
             }
             return segmentIndexesCache.get(

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
@@ -62,10 +62,13 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
 
         this.chunkIndex = manifest.chunkIndex();
 
-        final Chunk firstChunk = getFirstChunk(range.from);
+        if (range.isEmpty()) {
+            throw new IllegalArgumentException("range cannot be empty");
+        }
+        final Chunk firstChunk = getFirstChunk(range.firstPosition());
         startChunkId = firstChunk.id;
         currentChunkId = startChunkId;
-        final Chunk lastChunk = getLastChunk(range.to);
+        final Chunk lastChunk = getLastChunk(range.lastPosition());
         lastChunkId = lastChunk.id;
     }
 
@@ -107,7 +110,7 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
         final boolean isAtLastChunk = currentChunkId == lastChunkId;
         final boolean isSingleChunk = isAtFirstChunk && isAtLastChunk;
         if (isSingleChunk) {
-            final int toSkip = range.from - chunkStartPosition;
+            final int toSkip = range.firstPosition() - chunkStartPosition;
             try {
                 chunkContent.skip(toSkip);
                 final int chunkSize = range.size();
@@ -117,7 +120,7 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
             }
         } else {
             if (isAtFirstChunk) {
-                final int toSkip = range.from - chunkStartPosition;
+                final int toSkip = range.firstPosition() - chunkStartPosition;
                 try {
                     chunkContent.skip(toSkip);
                 } catch (final IOException e) {
@@ -125,7 +128,7 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
                 }
             }
             if (isAtLastChunk) {
-                final int chunkSize = range.to - chunkStartPosition + 1;
+                final int chunkSize = range.lastPosition() - chunkStartPosition + 1;
                 chunkContent = new BoundedInputStream(chunkContent, chunkSize);
             }
         }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/index/AbstractChunkIndex.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/index/AbstractChunkIndex.java
@@ -113,7 +113,9 @@ public abstract class AbstractChunkIndex implements ChunkIndex {
     public List<Chunk> chunksForRange(final BytesRange bytesRange) {
         Chunk current;
         final var result = new ArrayList<Chunk>();
-        for (int i = bytesRange.from; i <= bytesRange.to && i < originalFileSize; i += current.originalSize) {
+        for (int i = bytesRange.firstPosition();
+             i <= bytesRange.lastPosition() && i < originalFileSize;
+             i += current.originalSize) {
             current = findChunkForOriginalOffset(i);
             result.add(current);
         }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/ChunkTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/ChunkTest.java
@@ -25,8 +25,8 @@ public class ChunkTest {
     void rangeIsInclusive() {
         final Chunk chunk = new Chunk(0, 0, 10, 0, 12);
 
-        assertThat(chunk.range().from).isEqualTo(0);
-        assertThat(chunk.range().to).isEqualTo(11);
+        assertThat(chunk.range().firstPosition()).isZero();
         assertThat(chunk.range().size()).isEqualTo(12);
+        assertThat(chunk.range().maybeLastPosition()).hasValue(11);
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1BuilderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentIndexesV1BuilderTest.java
@@ -18,6 +18,8 @@ package io.aiven.kafka.tieredstorage.manifest;
 
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
 
+import io.aiven.kafka.tieredstorage.storage.BytesRange;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,4 +86,22 @@ class SegmentIndexesV1BuilderTest {
         assertThat(indexes.transaction()).isNull();
     }
 
+    @Test
+    void shouldBuildWithEmptyIndex() {
+        final var indexes = new SegmentIndexesV1Builder()
+            .add(RemoteStorageManager.IndexType.OFFSET, 0)
+            .add(RemoteStorageManager.IndexType.TIMESTAMP, 1)
+            .add(RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT, 0)
+            .add(RemoteStorageManager.IndexType.LEADER_EPOCH, 1)
+            .add(RemoteStorageManager.IndexType.TRANSACTION, 0)
+            .build();
+        assertThat(indexes.offset()).isEqualTo(new SegmentIndexV1(0, 0));
+        assertThat(indexes.offset().range()).isEqualTo(BytesRange.ofFromPositionAndSize(0, 0));
+        assertThat(indexes.timestamp()).isEqualTo(new SegmentIndexV1(0, 1));
+        assertThat(indexes.producerSnapshot()).isEqualTo(new SegmentIndexV1(1, 0));
+        assertThat(indexes.producerSnapshot().range()).isEqualTo(BytesRange.of(1, -1));
+        assertThat(indexes.leaderEpoch()).isEqualTo(new SegmentIndexV1(1, 1));
+        assertThat(indexes.transaction()).isEqualTo(new SegmentIndexV1(2, 0));
+        assertThat(indexes.transaction().range()).isEqualTo(BytesRange.empty(2));
+    }
 }

--- a/storage/azure/src/main/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorage.java
+++ b/storage/azure/src/main/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorage.java
@@ -142,8 +142,12 @@ public class AzureBlobStorage implements StorageBackend {
     @Override
     public InputStream fetch(final ObjectKey key, final BytesRange range) throws StorageBackendException {
         try {
+            if (range.isEmpty()) {
+                return InputStream.nullInputStream();
+            }
+
             return blobContainerClient.getBlobClient(key.value()).openInputStream(
-                new BlobRange(range.from, (long) range.size()), null);
+                new BlobRange(range.firstPosition(), (long) range.size()), null);
         } catch (final BlobStorageException e) {
             if (e.getStatusCode() == 404) {
                 throw new KeyNotFoundException(this, key, e);

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/BytesRange.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/BytesRange.java
@@ -16,14 +16,16 @@
 
 package io.aiven.kafka.tieredstorage.storage;
 
+import java.util.OptionalInt;
+
 /**
  * Byte range with from and to edges; where `to` cannot be less than `from`
  * --unless to represent empty range where to is -1.
  * Both, `from` and `to`, are inclusive positions.
  */
 public class BytesRange {
-    public final int from;
-    public final int to;
+    final int from;
+    final int to;
 
     BytesRange(final int from, final int to) {
         if (from < 0) {
@@ -36,8 +38,33 @@ public class BytesRange {
         this.to = to;
     }
 
+    public int firstPosition() {
+        return from;
+    }
+
+    /**
+     * @return empty if size == 0, otherwise last position (inclusive)
+     */
+    public OptionalInt maybeLastPosition() {
+        if (isEmpty()) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(to);
+    }
+
+    public int lastPosition() {
+        if (isEmpty()) {
+            throw new IllegalStateException("No last position, range is empty");
+        }
+        return to;
+    }
+
+    public boolean isEmpty() {
+        return to == -1;
+    }
+
     public int size() {
-        if (to == -1) {
+        if (isEmpty()) {
             return 0;
         }
         return to - from + 1;
@@ -64,7 +91,10 @@ public class BytesRange {
 
     @Override
     public String toString() {
-        return "bytes=" + from + "-" + to;
+        return "BytesRange{"
+            + "position=" + firstPosition()
+            + ", size=" + size()
+            + '}';
     }
 
     public static BytesRange of(final int from, final int to) {

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/BytesRange.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/BytesRange.java
@@ -17,8 +17,9 @@
 package io.aiven.kafka.tieredstorage.storage;
 
 /**
- * Byte range with from and to edges; where to cannot be less than from.
- * Both, from and to, are inclusive positions.
+ * Byte range with from and to edges; where `to` cannot be less than `from`
+ * --unless to represent empty range where to is -1.
+ * Both, `from` and `to`, are inclusive positions.
  */
 public class BytesRange {
     public final int from;
@@ -28,7 +29,7 @@ public class BytesRange {
         if (from < 0) {
             throw new IllegalArgumentException("from cannot be negative, " + from + " given");
         }
-        if (to < from) {
+        if (to != -1 && to < from) {
             throw new IllegalArgumentException("to cannot be less than from, from=" + from + ", to=" + to + " given");
         }
         this.from = from;
@@ -36,6 +37,9 @@ public class BytesRange {
     }
 
     public int size() {
+        if (to == -1) {
+            return 0;
+        }
         return to - from + 1;
     }
 
@@ -67,7 +71,14 @@ public class BytesRange {
         return new BytesRange(from, to);
     }
 
+    public static BytesRange empty(final int from) {
+        return new BytesRange(from, -1);
+    }
+
     public static BytesRange ofFromPositionAndSize(final int from, final int size) {
+        if (size == 0) {
+            return empty(from);
+        }
         return new BytesRange(from, from + size - 1);
     }
 

--- a/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/BytesRangeTest.java
+++ b/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/BytesRangeTest.java
@@ -52,4 +52,14 @@ class BytesRangeTest {
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("to cannot be less than from, from=2, to=1 given");
     }
+
+    @Test
+    void testEmptyRange() {
+        final BytesRange range = BytesRange.ofFromPositionAndSize(1, 0);
+        assertThat(range.size()).isEqualTo(0);
+        final BytesRange range2 = BytesRange.of(1, -1);
+        assertThat(range2.size()).isEqualTo(0);
+        final BytesRange range3 = BytesRange.empty(1);
+        assertThat(range3.size()).isEqualTo(0);
+    }
 }

--- a/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/BytesRangeTest.java
+++ b/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/BytesRangeTest.java
@@ -17,6 +17,8 @@
 package io.aiven.kafka.tieredstorage.storage;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,15 +28,15 @@ class BytesRangeTest {
     @Test
     void testMinimalRange() {
         final BytesRange range = BytesRange.of(1, 1);
-        assertThat(range.from).isEqualTo(1);
-        assertThat(range.to).isEqualTo(1);
-        assertThat(range.size()).isEqualTo(1);
+        assertThat(range.from).isOne();
+        assertThat(range.to).isOne();
+        assertThat(range.size()).isOne();
     }
 
     @Test
     void testProperRange() {
         final BytesRange range = BytesRange.of(1, 2);
-        assertThat(range.from).isEqualTo(1);
+        assertThat(range.from).isOne();
         assertThat(range.to).isEqualTo(2);
         assertThat(range.size()).isEqualTo(2);
     }
@@ -53,13 +55,22 @@ class BytesRangeTest {
             .hasMessage("to cannot be less than from, from=2, to=1 given");
     }
 
-    @Test
-    void testEmptyRange() {
-        final BytesRange range = BytesRange.ofFromPositionAndSize(1, 0);
-        assertThat(range.size()).isEqualTo(0);
-        final BytesRange range2 = BytesRange.of(1, -1);
-        assertThat(range2.size()).isEqualTo(0);
-        final BytesRange range3 = BytesRange.empty(1);
-        assertThat(range3.size()).isEqualTo(0);
+    static BytesRange[] emptyRanges() {
+        return new BytesRange[] {
+            BytesRange.ofFromPositionAndSize(1, 0),
+            BytesRange.of(1, -1),
+            BytesRange.empty(1)
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyRanges")
+    void testEmptyRange(final BytesRange range1) {
+        assertThat(range1.isEmpty()).isTrue();
+        assertThat(range1.size()).isZero();
+        assertThat(range1.maybeLastPosition()).isEmpty();
+        assertThatThrownBy(range1::lastPosition)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("No last position, range is empty");
     }
 }

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
@@ -87,10 +87,14 @@ public class S3Storage implements StorageBackend {
     @Override
     public InputStream fetch(final ObjectKey key, final BytesRange range) throws StorageBackendException {
         try {
+            if (range.isEmpty()) {
+                return InputStream.nullInputStream();
+            }
+            
             final GetObjectRequest getRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(key.value())
-                .range(range.toString())
+                .range(formatRange(range))
                 .build();
             return s3Client.getObject(getRequest);
         } catch (final AwsServiceException e) {
@@ -103,6 +107,10 @@ public class S3Storage implements StorageBackend {
 
             throw new StorageBackendException("Failed to fetch " + key, e);
         }
+    }
+
+    private String formatRange(final BytesRange range) {
+        return "bytes=" + range.firstPosition() + "-" + range.lastPosition();
     }
 
     @Override


### PR DESCRIPTION
Given that indexes could be empty, inclusive ranges should be able to represent the case where size is zero. 
To do this, `to=-1` is proposed to represent ranges that are empty.

Historically, ranges were designed only for segments where empty files were not possible. As recently empty indexes became a possibility when small segment files are created, then the initial design of BytesRange became an issue as it's designed as inclusive-inclusive. 