### PR TITLE
feat: extend object deleter to delete multiple keys at once when supported by back-end

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Sensor;
@@ -598,10 +600,10 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
         final long startedMs = time.milliseconds();
 
         try {
-            for (final ObjectKeyFactory.Suffix suffix : ObjectKeyFactory.Suffix.values()) {
-                final ObjectKey key = objectKeyFactory.key(remoteLogSegmentMetadata, suffix);
-                deleter.delete(key);
-            }
+            final Set<ObjectKey> keys = Arrays.stream(ObjectKeyFactory.Suffix.values())
+                .map(s -> objectKeyFactory.key(remoteLogSegmentMetadata, s))
+                .collect(Collectors.toSet());
+            deleter.delete(keys);
         } catch (final Exception e) {
             metrics.recordSegmentDeleteError(remoteLogSegmentMetadata.remoteLogSegmentId()
                 .topicIdPartition().topicPartition());

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -55,6 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.DOUBLE;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mockConstruction;
@@ -225,7 +226,7 @@ class RemoteStorageManagerMetricsTest {
             FileSystemStorage.class,
             (mock, context) -> {
                 doThrow(testException).when(mock).upload(any(), any());
-                doThrow(testException).when(mock).delete(any());
+                doThrow(testException).when(mock).delete(anySet());
             }
         )) {
 

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/ObjectDeleter.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/ObjectDeleter.java
@@ -16,6 +16,8 @@
 
 package io.aiven.kafka.tieredstorage.storage;
 
+import java.util.Set;
+
 public interface ObjectDeleter {
     /**
      * Delete the object with the specified key.
@@ -23,4 +25,15 @@ public interface ObjectDeleter {
      * <p>If the object doesn't exist, the operation still succeeds as it is idempotent.
      */
     void delete(ObjectKey key) throws StorageBackendException;
+
+    /**
+     * Delete objects from a set of keys.
+     *
+     * <p>If the object doesn't exist, the operation still succeeds as it is idempotent.
+     */
+    default void delete(Set<ObjectKey> keys) throws StorageBackendException {
+        for (final var key : keys) {
+            delete(key);
+        }
+    }
 }

--- a/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageMetricsTest.java
+++ b/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageMetricsTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
+import java.util.Set;
 
 import io.aiven.kafka.tieredstorage.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
@@ -111,6 +112,7 @@ class S3StorageMetricsTest {
             fetch.readAllBytes();
         }
         storage.delete(key);
+        storage.delete(Set.of(key));
 
         final InputStream failingInputStream = mock(InputStream.class);
         final IOException exception = new IOException("test");
@@ -150,6 +152,18 @@ class S3StorageMetricsTest {
             .asInstanceOf(DOUBLE)
             .isGreaterThan(0.0);
         assertThat(MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "delete-object-time-max"))
+            .asInstanceOf(DOUBLE)
+            .isGreaterThan(0.0);
+
+        assertThat(MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "delete-objects-requests-rate"))
+            .asInstanceOf(DOUBLE)
+            .isGreaterThan(0.0);
+        assertThat(MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "delete-objects-requests-total"))
+            .isEqualTo(1.0);
+        assertThat(MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "delete-objects-time-avg"))
+            .asInstanceOf(DOUBLE)
+            .isGreaterThan(0.0);
+        assertThat(MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "delete-objects-time-max"))
             .asInstanceOf(DOUBLE)
             .isGreaterThan(0.0);
 

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
@@ -74,6 +74,8 @@ class MetricCollector implements MetricPublisher {
         latencyMetrics.put("PutObject", createLatencySensor("put-object-time"));
         requestMetrics.put("DeleteObject", createRequestsSensor("delete-object-requests"));
         latencyMetrics.put("DeleteObject", createLatencySensor("delete-object-time"));
+        requestMetrics.put("DeleteObjects", createRequestsSensor("delete-objects-requests"));
+        latencyMetrics.put("DeleteObjects", createLatencySensor("delete-objects-time"));
         requestMetrics.put("AbortMultipartUpload", createRequestsSensor("abort-multipart-upload-requests"));
         latencyMetrics.put("AbortMultipartUpload", createLatencySensor("abort-multipart-upload-time"));
 


### PR DESCRIPTION
Some Storage back-ends have the ability to delete multiple objects at once. To allow them to use this optimization, the ObjectDeleter interface is extended to allow passing multiple object keys at once.

Fix #319

PS. Was considering GCS initially, but given that FakeGcs server doesn't seem to properly handle the `delete(List of BlobId)` -- at least metrics where not processed -- and implementation seems to be syntactic sugar; then I decided to postpone it and only focused on S3.