### PR TITLE
feat: remove orphan objects if copy fails at any point

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentEncryptionMetadataV1.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentEncryptionMetadataV1.java
@@ -21,6 +21,8 @@ import javax.crypto.SecretKey;
 import java.util.Arrays;
 import java.util.Objects;
 
+import io.aiven.kafka.tieredstorage.security.DataKeyAndAAD;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -35,6 +37,10 @@ public class SegmentEncryptionMetadataV1 implements SegmentEncryptionMetadata {
                                        @JsonProperty(value = "aad", required = true) final byte[] aad) {
         this.dataKey = Objects.requireNonNull(dataKey, "dataKey cannot be null");
         this.aad = Objects.requireNonNull(aad, "aad cannot be null");
+    }
+
+    public SegmentEncryptionMetadataV1(final DataKeyAndAAD dataKeyAndAAD) {
+        this(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad);
     }
 
     @Override


### PR DESCRIPTION
Given that there are at least 3 objects uploaded per segment, and it could fail at any stage, the plugin should guard that the chances for orphan objects is minimal.

Be aware, the first commit includes a set of refactoring around RSM upload operations to cleanup and simplify the testing of the 2nd (main) commit. See commit messages for more details. 