### PR TITLE
fix: extend possible root causes message

### DIFF
--- a/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
+++ b/storage/azure/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/azure/AzureBlobStorageSocks5Test.java
@@ -118,10 +118,12 @@ class AzureBlobStorageSocks5Test extends BaseSocks5Test<AzureBlobStorage> {
 
     @Override
     protected Iterable<String> possibleRootCauseMessagesWhenNoProxy() {
-        // Either - or, it seems it depends on the JVM version.
+        // Either - or, it seems it depends on the JVM version or OS.
         final String possibleMessage1 = String.format(
             "%s: Temporary failure in name resolution", azuriteContainerNetworkAlias);
         final String possibleMessage2 = String.format("%s: Name or service not known", azuriteContainerNetworkAlias);
-        return List.of(possibleMessage1, possibleMessage2);
+        final String possibleMessage3 = String.format(
+            "%s: nodename nor servname provided, or not known", azuriteContainerNetworkAlias);
+        return List.of(possibleMessage1, possibleMessage2, possibleMessage3);
     }
 }


### PR DESCRIPTION
Seems the current possible messages need to be extended when the integration tests for proxy is running on a mac. The exceptions could be slightly different.

Some similarity with other stacks trying to handle similar errors: [1]

[1]: https://github.com/Shopify/semian/blob/ebe30df94cebc74d28e020206d6a2fa2019aeed7/lib/semian/redis.rb#L166
