### PR TITLE
feat: add rate limited input stream for uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ With this approach, it's possible to start using a new KEK for new data: keep th
 
 ### Uploads
 
+#### Rate Limit
+
+TBD
+
 #### S3 Multipart Upload
 
 When uploading processed segments and indexes, multipart upload is used to put files on S3 back-end.

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,8 @@ subprojects {
         testcontainersVersion = "1.19.7"
 
         testcontainersFakeGcsServerVersion = "0.2.0"
+
+        bucket4jVersion = "8.12.1"
     }
 
     dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation "commons-io:commons-io:$apacheCommonsIOVersion"
     implementation project(':commons')
 
+    implementation "com.bucket4j:bucket4j_jdk11-core:$bucket4jVersion"
+
     testImplementation(testFixtures(project(":storage:core")))
     testImplementation(project(":storage:filesystem"))
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -90,11 +90,13 @@ import io.aiven.kafka.tieredstorage.transform.DecryptionChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.DetransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.DetransformFinisher;
 import io.aiven.kafka.tieredstorage.transform.EncryptionChunkEnumeration;
+import io.aiven.kafka.tieredstorage.transform.RateLimitedInputStream;
 import io.aiven.kafka.tieredstorage.transform.TransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.transform.TransformFinisher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.github.bucket4j.Bucket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,6 +130,8 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
     private SegmentManifestProvider segmentManifestProvider;
     private SegmentIndexesCache segmentIndexesCache;
+
+    private Bucket rateLimitingBucket;
 
     public RemoteStorageManager() {
         this(Time.SYSTEM);
@@ -179,6 +183,9 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
         customMetadataSerde = new SegmentCustomMetadataSerde();
         customMetadataFields = config.customMetadataKeysIncluded();
+
+        config.uploadRateLimit().ifPresent(value ->
+            rateLimitingBucket = RateLimitedInputStream.rateLimitBucket(value));
     }
 
     // for testing
@@ -240,8 +247,11 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                         () -> aesEncryptionProvider.encryptionCipher(dataKeyAndAAD));
                     encryptionMetadata = new SegmentEncryptionMetadataV1(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad);
                 }
-                final TransformFinisher transformFinisher =
-                    new TransformFinisher(transformEnum, remoteLogSegmentMetadata.segmentSizeInBytes());
+                final TransformFinisher transformFinisher = new TransformFinisher(
+                    transformEnum,
+                    remoteLogSegmentMetadata.segmentSizeInBytes(),
+                    rateLimitingBucket
+                );
                 uploadSegmentLog(remoteLogSegmentMetadata, transformFinisher, customMetadataBuilder);
                 chunkIndex = transformFinisher.chunkIndex();
             }
@@ -412,7 +422,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                     transformEnum,
                     () -> aesEncryptionProvider.encryptionCipher(dataKeyAndAAD));
             }
-            final var transformFinisher = new TransformFinisher(transformEnum, size);
+            final var transformFinisher = new TransformFinisher(transformEnum, size, rateLimitingBucket);
             final var inputStream = transformFinisher.nextElement();
             segmentIndexBuilder.add(indexType, singleChunk(transformFinisher.chunkIndex()).range().size());
             return inputStream;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,6 +34,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Utils;
 
+import io.aiven.kafka.tieredstorage.config.validators.Null;
 import io.aiven.kafka.tieredstorage.metadata.SegmentCustomMetadataField;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 
@@ -94,6 +96,11 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
     private static final String CUSTOM_METADATA_FIELDS_INCLUDE_DOC = "Custom Metadata to be stored along "
         + "Remote Log Segment metadata on Remote Log Metadata Manager back-end. "
         + "Allowed values: " + Arrays.toString(SegmentCustomMetadataField.names());
+
+    private static final String UPLOAD_RATE_LIMIT_BYTES_CONFIG = "upload.rate.limit.bytes.per.second";
+    private static final String UPLOAD_RATE_LIMIT_BYTES_DOC = "Upper bound on bytes to upload "
+        + "(therefore read from disk) per second. Rate limit must be equal or larger than 1 MiB/sec "
+        + "as minimal upload throughput.";
 
     private static final ConfigDef CONFIG;
 
@@ -207,6 +214,22 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
             ConfigDef.ValidList.in(SegmentCustomMetadataField.names()),
             ConfigDef.Importance.LOW,
             CUSTOM_METADATA_FIELDS_INCLUDE_DOC);
+
+        CONFIG.define(
+            UPLOAD_RATE_LIMIT_BYTES_CONFIG,
+            ConfigDef.Type.INT,
+            null,
+            // at least 1MiB. Not hard-limit, but to avoid a rate too low that could affect other components.
+            Null.or(ConfigDef.Range.atLeast(1024 * 1024)),
+            ConfigDef.Importance.MEDIUM,
+            UPLOAD_RATE_LIMIT_BYTES_DOC
+        );
+    }
+
+    public OptionalInt uploadRateLimit() {
+        return Optional.ofNullable(getInt(UPLOAD_RATE_LIMIT_BYTES_CONFIG)).stream()
+            .mapToInt(Integer::intValue)
+            .findAny();
     }
 
     /**

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/RateLimitedInputStream.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/RateLimitedInputStream.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.transform;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.local.SynchronizationStrategy;
+
+/**
+ * Input Stream with a limited rate of reading from source.
+ * Aims to provide a stable upload speed that does not affect other streams of work in a broker.
+ * Rate limiting is only implemented for {@code InputStream#read(bytes, offset, len)} as rate limiting individual reads
+ * is too expensive.
+ */
+public class RateLimitedInputStream extends FilterInputStream {
+    // default buffer size used by InputStream#DEFAULT_BUFFER_SIZE when transferring to output stream
+    static final int MIN_RATE = 8192;
+
+    final Bucket bucket;
+
+    public RateLimitedInputStream(final InputStream delegated, final Bucket bucket) {
+        super(delegated);
+        this.bucket = bucket;
+    }
+
+    public static Bucket rateLimitBucket(final int uploadRate) {
+        final int rate = Math.max(uploadRate, MIN_RATE);
+        return Bucket.builder()
+            .withSynchronizationStrategy(SynchronizationStrategy.LOCK_FREE)
+            .addLimit(limit ->
+                limit.capacity(rate)
+                    // every 100ms a 10th of the chunk size is added back to bucket
+                    .refillGreedy(rate, Duration.ofSeconds(1)))
+            .build();
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        // only block when some bytes are requested
+        if (len > 0) {
+            try {
+                bucket.asBlocking().consume(len);
+            } catch (final InterruptedException e) {
+                throw new RuntimeException("Rate limited consumption of input stream interrupted", e);
+            }
+        }
+
+        // forward request
+        final int read = super.read(b, off, len);
+
+        // compensate for tokens buffered but not read
+        if (read > -1) {
+            // if number of bytes read is less than buffer, return tokens
+            if (len > read) {
+                bucket.forceAddTokens(len - read);
+            }
+        } else {
+            // if stream is empty, return tokens
+            if (len > 0) {
+                bucket.forceAddTokens(len);
+            }
+        }
+
+        return read;
+    }
+
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfigTest.java
@@ -53,6 +53,7 @@ class RemoteStorageManagerConfigTest {
         assertThat(config.keyPrefix()).isEmpty();
         assertThat(config.keyPrefixMask()).isFalse();
         assertThat(config.customMetadataKeysIncluded()).isEmpty();
+        assertThat(config.uploadRateLimit()).isEmpty();
     }
 
     @Test
@@ -350,5 +351,33 @@ class RemoteStorageManagerConfigTest {
             )
         );
         assertThat(config.keyPrefixMask()).isTrue();
+    }
+
+    @Test
+    void uploadRateLimitInvalid() {
+        assertThatThrownBy(() ->
+            new RemoteStorageManagerConfig(
+                Map.of(
+                    "storage.backend.class", NoopStorageBackend.class.getCanonicalName(),
+                    "chunk.size", "123",
+                    "upload.rate.limit.bytes.per.second", "122"
+                )
+            ))
+            .isInstanceOf(ConfigException.class)
+            .hasMessage("Invalid value 122 for configuration upload.rate.limit.bytes.per.second: "
+                + "Value must be at least 1048576");
+    }
+
+    @Test
+    void uploadRateLimitValid() {
+        final int limit = 1024 * 1024;
+        final var config = new RemoteStorageManagerConfig(
+            Map.of(
+                "storage.backend.class", NoopStorageBackend.class.getCanonicalName(),
+                "chunk.size", "123",
+                "upload.rate.limit.bytes.per.second", Integer.toString(limit)
+            )
+        );
+        assertThat(config.uploadRateLimit()).hasValue(limit);
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/RateLimitedInputStreamTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/RateLimitedInputStreamTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.transform;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Arrays;
+
+import io.github.bucket4j.Bucket;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitedInputStreamTest {
+    @Test
+    void testDoesNotBlockRead() {
+        // Given a bucket with min size of default buffer
+        final Bucket bucket = RateLimitedInputStream.rateLimitBucket(1);
+        // When a stream of size less than capacity is read
+        final byte[] bytes = new byte[RateLimitedInputStream.MIN_RATE - 1];
+        final ByteArrayInputStream source = new ByteArrayInputStream(bytes);
+        final InputStream test = new RateLimitedInputStream(source, bucket);
+        // Then read should happen without blocking, i.e. less than 1 sec
+        await().atMost(Duration.ofSeconds(1))
+            .until(() -> {
+                test.readAllBytes();
+                return true;
+            });
+    }
+
+    @Test
+    void testBlocksRead() {
+        // Given a bucket with min size of default buffer
+        final Bucket bucket = RateLimitedInputStream.rateLimitBucket(1);
+        // When a stream of size larger than capacity is read
+        final byte[] bytes = new byte[RateLimitedInputStream.MIN_RATE + 1];
+        Arrays.fill(bytes, (byte) 0);
+        final InputStream test = new RateLimitedInputStream(new ByteArrayInputStream(bytes), bucket);
+        // Then read should block while bucket is refill; taking at least 1 sec but not more than 2
+        await().atLeast(Duration.ofSeconds(1))
+            .until(() -> {
+                test.readAllBytes();
+                return true;
+            });
+    }
+
+    @Test
+    void testBlocksOnSeparateStreams() {
+        // Given a bucket with min size of default buffer
+        final Bucket bucket = RateLimitedInputStream.rateLimitBucket(1);
+        // When 2 streams with less than buffer size
+        final byte[] bytes0 = new byte[RateLimitedInputStream.MIN_RATE - 1];
+        Arrays.fill(bytes0, (byte) 0);
+        final InputStream test0 = new RateLimitedInputStream(new ByteArrayInputStream(bytes0), bucket);
+        final byte[] bytes1 = new byte[RateLimitedInputStream.MIN_RATE - 1];
+        Arrays.fill(bytes1, (byte) 0);
+        final InputStream test1 = new RateLimitedInputStream(new ByteArrayInputStream(bytes1), bucket);
+        // Then read should not block on first stream
+        await().atMost(Duration.ofSeconds(1))
+            .until(() -> {
+                test0.readAllBytes();
+                return true;
+            });
+        // but should block on the second one for a second to refill bucket consumed by first stream
+        // minus 100 to account for some timing skew in between runs
+        await().atLeast(Duration.ofSeconds(1).minusMillis(100))
+            .until(() -> {
+                test1.readAllBytes();
+                return true;
+            });
+    }
+
+    @Test
+    void testAllNecessaryCallsAreRateLimited() throws IOException {
+        // bucket never used on single byte reads
+        Bucket bucket = spy(RateLimitedInputStream.rateLimitBucket(1));
+        var rateLimitedInputStream = new RateLimitedInputStream(new ByteArrayInputStream(new byte[100]), bucket);
+        rateLimitedInputStream.read();
+        verify(bucket, Mockito.never()).asBlocking();
+
+        // bucket only used on reads by range
+        final var buf = new byte[10];
+        bucket = spy(RateLimitedInputStream.rateLimitBucket(1));
+        rateLimitedInputStream = new RateLimitedInputStream(new ByteArrayInputStream(new byte[100]), bucket);
+        rateLimitedInputStream.read(buf);
+        verify(bucket).asBlocking();
+
+        bucket = spy(RateLimitedInputStream.rateLimitBucket(1));
+        rateLimitedInputStream = new RateLimitedInputStream(new ByteArrayInputStream(new byte[100]), bucket);
+        rateLimitedInputStream.read(buf, 0, 10);
+        verify(bucket).asBlocking();
+
+        bucket = spy(RateLimitedInputStream.rateLimitBucket(1));
+        rateLimitedInputStream = new RateLimitedInputStream(new ByteArrayInputStream(new byte[100]), bucket);
+        rateLimitedInputStream.readNBytes(10);
+        verify(bucket).asBlocking();
+
+        bucket = spy(RateLimitedInputStream.rateLimitBucket(1));
+        rateLimitedInputStream = new RateLimitedInputStream(new ByteArrayInputStream(new byte[100]), bucket);
+        rateLimitedInputStream.readNBytes(buf, 0, 10);
+        verify(bucket).asBlocking();
+
+        bucket = spy(RateLimitedInputStream.rateLimitBucket(1));
+        rateLimitedInputStream = new RateLimitedInputStream(new ByteArrayInputStream(new byte[100]), bucket);
+        rateLimitedInputStream.readAllBytes();
+        verify(bucket, atLeastOnce()).asBlocking();
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformFinisherTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformFinisherTest.java
@@ -42,7 +42,7 @@ class TransformFinisherTest {
 
     @Test
     void getIndexBeforeUsing() {
-        final TransformFinisher finisher = new TransformFinisher(new FakeDataEnumerator(3), 7);
+        final TransformFinisher finisher = new TransformFinisher(new FakeDataEnumerator(3), 7, null);
         assertThatThrownBy(() -> finisher.chunkIndex())
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Chunk index was not built, was finisher used?");
@@ -50,14 +50,14 @@ class TransformFinisherTest {
 
     @Test
     void nullInnerEnumeration() {
-        assertThatThrownBy(() -> new TransformFinisher(null, 100))
+        assertThatThrownBy(() -> new TransformFinisher(null, 100, null))
             .isInstanceOf(NullPointerException.class)
             .hasMessage("inner cannot be null");
     }
 
     @Test
     void negativeOriginalFileSize() {
-        assertThatThrownBy(() -> new TransformFinisher(inner, -1))
+        assertThatThrownBy(() -> new TransformFinisher(inner, -1, null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("originalFileSize must be non-negative, -1 given");
     }
@@ -66,7 +66,7 @@ class TransformFinisherTest {
     @MethodSource("provideForBuildIndexAndReturnCorrectInputStreams")
     void buildIndexAndReturnCorrectInputStreams(final Integer transformedChunkSize,
                                                 final Class<ChunkIndex> indexType) throws IOException {
-        final TransformFinisher finisher = new TransformFinisher(new FakeDataEnumerator(transformedChunkSize), 7);
+        final TransformFinisher finisher = new TransformFinisher(new FakeDataEnumerator(transformedChunkSize), 7, null);
         assertThat(finisher.hasMoreElements()).isTrue();
         assertThat(finisher.nextElement().readAllBytes()).isEqualTo(new byte[] {0, 1, 2});
         assertThat(finisher.hasMoreElements()).isTrue();

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformsEndToEndTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformsEndToEndTest.java
@@ -79,8 +79,8 @@ public class TransformsEndToEndTest extends AesKeyAwareTest {
             transformEnum = new EncryptionChunkEnumeration(transformEnum, AesKeyAwareTest::encryptionCipherSupplier);
         }
         final var transformFinisher = chunkSize == 0
-            ? new TransformFinisher(transformEnum)
-            : new TransformFinisher(transformEnum, ORIGINAL_SIZE);
+            ? new TransformFinisher(transformEnum, null)
+            : new TransformFinisher(transformEnum, ORIGINAL_SIZE, null);
         final byte[] uploadedData;
         final ChunkIndex chunkIndex;
         try (final var sis = transformFinisher.toInputStream()) {

--- a/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
+++ b/e2e/src/test/java/io/aiven/kafka/tieredstorage/e2e/SingleBrokerTest.java
@@ -187,6 +187,8 @@ abstract class SingleBrokerTest {
                 "io.aiven.kafka.tieredstorage.RemoteStorageManager")
             .withEnv("KAFKA_RSM_CONFIG_CHUNK_SIZE", Integer.toString(CHUNK_SIZE))
             .withEnv("KAFKA_RSM_CONFIG_CUSTOM_METADATA_FIELDS_INCLUDE", "REMOTE_SIZE")
+            // upload rate at smallest rate
+            .withEnv("KAFKA_RSM_CONFIG_UPLOAD_RATE_LIMIT_BYTES_PER_SECOND", Integer.toString(1024 * 1024))
             // chunk caching
             .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_CLASS",
                 "io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache")


### PR DESCRIPTION
When uploading segments, there is no limitation on how many resources to use (CPU, Network, Disk bandwidth). Given that many threads are started on the same broker and upload segments concurrently, this could affect the broker performance.

This PR aims to provide a limitation for the input stream offered to storage backends to limit how many bytes can be read per second. To do that, Bucket4j rate limiting library is used to provide a bucket with the configured upper bound per RSM (i.e. per broker).

Inspired by #521 