### PR TITLE
fix(s3): reducing array copying on S3 output stream

### DIFF
--- a/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageTest.java
+++ b/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageTest.java
@@ -24,6 +24,7 @@ import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 import io.aiven.kafka.tieredstorage.storage.TestObjectKey;
 import io.aiven.kafka.tieredstorage.storage.TestUtils;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,8 +51,8 @@ public class S3StorageTest extends BaseStorageTest {
 
     @BeforeAll
     static void setUpClass() {
-        final var clientBuilder = S3Client.builder();
-        clientBuilder.region(Region.of(LOCALSTACK.getRegion()))
+        s3Client = S3Client.builder()
+            .region(Region.of(LOCALSTACK.getRegion()))
             .endpointOverride(LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3))
             .credentialsProvider(
                 StaticCredentialsProvider.create(
@@ -62,13 +63,19 @@ public class S3StorageTest extends BaseStorageTest {
                 )
             )
             .build();
-        s3Client = clientBuilder.build();
     }
 
     @BeforeEach
     void setUp(final TestInfo testInfo) {
         bucketName = TestUtils.testNameToBucketName(testInfo);
         s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+    }
+
+    @AfterAll
+    static void closeAll() {
+        if (s3Client != null) {
+            s3Client.close();
+        }
     }
 
     @Override

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
@@ -118,10 +118,15 @@ class MetricCollector implements MetricPublisher {
                     latency.record(durations.get(0).toMillis());
                 }
             } else {
-                log.warn("Latencies included on metric collection is larger than 1: " + metricValues);
+                log.warn(
+                    "Latencies included on metric collection is larger than 1: "
+                        + "metric values: {} and durations: {}",
+                    metricValues, durations);
             }
         } else {
-            log.warn("Operations included on metric collection is larger than 1: " + metricValues);
+            log.warn("Operations included on metric collection is larger than 1: "
+                + "metric values: {}",
+                metricValues);
         }
 
         final List<String> errorValues = metricCollection.childrenWithName("ApiCallAttempt")

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -169,8 +169,11 @@ public class S3MultiPartOutputStream extends OutputStream {
 
     private void flushBuffer(final int offset,
                              final int actualPartSize) {
-        final ByteArrayInputStream in = new ByteArrayInputStream(partBuffer.array(), offset, actualPartSize);
-        uploadPart(in, actualPartSize);
+        try (final ByteArrayInputStream in = new ByteArrayInputStream(partBuffer.array(), offset, actualPartSize)) {
+            uploadPart(in, actualPartSize);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
         partBuffer.clear();
     }
 

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -16,13 +16,14 @@
 
 package io.aiven.kafka.tieredstorage.storage.s3;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.kafka.common.utils.ByteBufferInputStream;
 
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 
@@ -93,16 +94,23 @@ public class S3MultiPartOutputStream extends OutputStream {
             return;
         }
         try {
-            final ByteBuffer source = ByteBuffer.wrap(b, off, len);
-            while (source.hasRemaining()) {
-                final int transferred = Math.min(partBuffer.remaining(), source.remaining());
-                final int offset = source.arrayOffset() + source.position();
-                // TODO: get rid of this array copying
-                partBuffer.put(source.array(), offset, transferred);
-                processedBytes += transferred;
-                source.position(source.position() + transferred);
+            final ByteBuffer inputBuffer = ByteBuffer.wrap(b, off, len);
+            while (inputBuffer.hasRemaining()) {
+                // copy batch to part buffer
+                final int inputLimit = inputBuffer.limit();
+                final int toCopy = Math.min(partBuffer.remaining(), inputBuffer.remaining());
+                final int positionAfterCopying = inputBuffer.position() + toCopy;
+                inputBuffer.limit(positionAfterCopying);
+                partBuffer.put(inputBuffer.slice());
+
+                // prepare current batch for next part
+                inputBuffer.limit(inputLimit);
+                inputBuffer.position(positionAfterCopying);
+
                 if (!partBuffer.hasRemaining()) {
-                    flushBuffer(0, partSize);
+                    partBuffer.position(0);
+                    partBuffer.limit(partSize);
+                    flushBuffer(partBuffer.slice(), partSize);
                 }
             }
         } catch (final RuntimeException e) {
@@ -115,9 +123,12 @@ public class S3MultiPartOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         if (!isClosed()) {
-            if (partBuffer.position() > 0) {
+            final int lastPosition = partBuffer.position();
+            if (lastPosition > 0) {
                 try {
-                    flushBuffer(partBuffer.arrayOffset(), partBuffer.position());
+                    partBuffer.position(0);
+                    partBuffer.limit(lastPosition);
+                    flushBuffer(partBuffer.slice(), lastPosition);
                 } catch (final RuntimeException e) {
                     log.error("Failed to upload last part {}, aborting transaction", uploadId, e);
                     abortUpload();
@@ -167,14 +178,14 @@ public class S3MultiPartOutputStream extends OutputStream {
         closed = true;
     }
 
-    private void flushBuffer(final int offset,
+    private void flushBuffer(final ByteBuffer buffer,
                              final int actualPartSize) {
-        try (final ByteArrayInputStream in = new ByteArrayInputStream(partBuffer.array(), offset, actualPartSize)) {
+        try (final InputStream in = new ByteBufferInputStream(buffer)) {
+            processedBytes += actualPartSize;
             uploadPart(in, actualPartSize);
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
-        partBuffer.clear();
     }
 
     private void uploadPart(final InputStream in, final int actualPartSize) {

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
@@ -54,12 +54,14 @@ public class S3Storage implements StorageBackend {
 
     @Override
     public long upload(final InputStream inputStream, final ObjectKey key) throws StorageBackendException {
-        try (final var out = s3OutputStream(key)) {
+        final var out = s3OutputStream(key);
+        try (out) {
             inputStream.transferTo(out);
-            return out.processedBytes();
         } catch (final IOException e) {
             throw new StorageBackendException("Failed to upload " + key, e);
         }
+        // getting the processed bytes after close to account last flush.
+        return out.processedBytes();
     }
 
     S3MultiPartOutputStream s3OutputStream(final ObjectKey key) {

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStreamTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStreamTest.java
@@ -17,6 +17,7 @@
 package io.aiven.kafka.tieredstorage.storage.s3;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -186,12 +187,21 @@ class S3MultiPartOutputStreamTest {
     @Test
     void writesMultipleMessages() throws Exception {
         final int bufferSize = 10;
-        final byte[] message = new byte[bufferSize];
 
+        final List<UploadPartRequest> uploadPartRequests = new ArrayList<>();
+        final List<RequestBody> requestBodies = new ArrayList<>();
         when(mockedS3.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
             .thenAnswer(invocation -> {
-                final UploadPartRequest up = invocation.getArgument(0);
-                return newUploadPartResponse("SOME_ETAG#" + up.partNumber());
+                final UploadPartRequest upload = invocation.getArgument(0);
+                final RequestBody originalBody = invocation.getArgument(1);
+                //emulate the behavior of S3 client otherwise we will get a wrong array in the memory
+                try (final InputStream inputStream = originalBody.contentStreamProvider().newStream()) {
+                    final RequestBody requestBody = RequestBody.fromBytes(inputStream.readAllBytes());
+                    requestBodies.add(requestBody);
+                }
+                uploadPartRequests.add(upload);
+
+                return newUploadPartResponse("SOME_ETAG#" + upload.partNumber());
             });
         when(mockedS3.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
             .thenReturn(CompleteMultipartUploadResponse.builder().build());
@@ -199,6 +209,7 @@ class S3MultiPartOutputStreamTest {
         final List<byte[]> expectedMessagesList = new ArrayList<>();
         final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, bufferSize, mockedS3);
         for (int i = 0; i < 3; i++) {
+            final byte[] message = new byte[bufferSize];
             random.nextBytes(message);
             out.write(message, 0, message.length);
             expectedMessagesList.add(message);
@@ -209,15 +220,14 @@ class S3MultiPartOutputStreamTest {
         assertThatCode(out::close).doesNotThrowAnyException();
 
         verify(mockedS3).createMultipartUpload(any(CreateMultipartUploadRequest.class));
-        verify(mockedS3, times(3)).uploadPart(uploadPartRequestCaptor.capture(), requestBodyCaptor.capture());
+        verify(mockedS3, times(3)).uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
         verify(mockedS3).completeMultipartUpload(completeMultipartUploadRequestCaptor.capture());
 
-        final List<UploadPartRequest> uploadRequests = uploadPartRequestCaptor.getAllValues();
         int counter = 0;
         for (final byte[] expectedMessage : expectedMessagesList) {
             assertUploadPartRequest(
-                uploadRequests.get(counter),
-                requestBodyCaptor.getValue(),
+                uploadPartRequests.get(counter),
+                requestBodies.get(counter),
                 bufferSize,
                 counter + 1,
                 expectedMessage);
@@ -245,10 +255,11 @@ class S3MultiPartOutputStreamTest {
                 final UploadPartRequest upload = invocation.getArgument(0);
                 final RequestBody originalBody = invocation.getArgument(1);
                 //emulate the behavior of S3 client otherwise we will get a wrong array in the memory
-                final RequestBody requestBody = RequestBody.fromBytes(originalBody.contentStreamProvider().newStream()
-                    .readAllBytes());
+                try (final InputStream inputStream = originalBody.contentStreamProvider().newStream()) {
+                    final RequestBody requestBody = RequestBody.fromBytes(inputStream.readAllBytes());
+                    requestBodies.add(requestBody);
+                }
                 uploadPartRequests.add(upload);
-                requestBodies.add(requestBody);
 
                 return newUploadPartResponse("SOME_ETAG#" + upload.partNumber());
             });


### PR DESCRIPTION
Use only ByteRange slices to pass bytes to S3 client operations and remove array copying.

Doing some benchmarks on the current implementation, the Arrays.copyOfRange dominates the memory allocation:

![image](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/assets/6180701/e2308998-5b82-48c8-adbc-f43dd62473eb)

 By switching to the ByteBuffer approach, this copying is removed:

![image](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/assets/6180701/095b578b-e664-4174-ba68-cab4710634d1)
