### PR TITLE
fix: handle race condition on cache retention

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskChunkCache.java
@@ -98,11 +98,16 @@ public class DiskChunkCache extends ChunkCache<Path> {
         return (key, path, cause) -> {
             try {
                 if (path != null) {
-                    final long fileSize = Files.size(path);
-                    Files.delete(path);
-                    metrics.chunkDeleted(fileSize);
-                    log.trace("Deleted cached file for key {} with path {} from cache directory."
-                        + " The reason of the deletion is {}", key, path, cause);
+                    if (Files.exists(path)) {
+                        final long fileSize = Files.size(path);
+                        Files.delete(path);
+                        metrics.chunkDeleted(fileSize);
+                        log.trace("Deleted cached file for key {} with path {} from cache directory."
+                            + " The reason of the deletion is {}", key, path, cause);
+                    } else {
+                        log.debug("Deletion of cached file for key {} with "
+                            + "path {} is requested by file is not found", key, path);
+                    }
                 } else {
                     log.warn("Path not present when trying to delete cached file for key {} from cache directory."
                         + " The reason of the deletion is {}", key, cause);


### PR DESCRIPTION
Cache removal listener-related tests (DiskChunkCacheMetricsTest and MemorySegmentIndexesCacheTest) are flaky. Recent evidence:

- https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/actions/runs/10206672059/job/28240015688?pr=576
- https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/actions/runs/10213446503/job/28258822803
- https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/actions/runs/10283516010/job/28457507975

To reproduce this locally, `@RepeatedTest(10000)` has been used.

The failure is caused by the timeout condition when waiting for a cache entry to be removed:

```
DiskChunkCacheMetricsTest > metrics() > repetition 279 of 1000 FAILED
    org.awaitility.core.ConditionTimeoutException: Condition with alias 'Deletion happens' didn't complete within 30 seconds because condition with lambda expression in io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCacheMetricsTest that uses javax.management.ObjectName was not fulfilled.
        at app//org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:167)
        at app//org.awaitility.core.CallableCondition.await(CallableCondition.java:78)
        at app//org.awaitility.core.CallableCondition.await(CallableCondition.java:26)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1006)
        at app//org.awaitility.core.ConditionFactory.until(ConditionFactory.java:975)
        at app//io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCacheMetricsTest.metrics(DiskChunkCacheMetricsTest.java:125)
```

Waiting for RemovalListener to be called just after inserting a couple of entries seem to not been deterministic, and retention.ms time boundary is needed to get the removal called within the time-frame of the test (default retention.ms = 10min). 


As a separate finding, while running this locally, I spot the exception of file not found after some thousand runs:

```
[2024-07-05 12:26:01,100] INFO DiskChunkCacheConfig values: 
	path = /var/folders/f_/6tkk7f6x7377dzmwfsqkdtk00000gq/T/junit16372691694497514473
	prefetch.max.size = 0
	retention.ms = 600000
	size = 1024
 (io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCacheConfig:370)
[2024-07-05 12:43:47,886] ERROR Failed to delete cached file for key ChunkKey(segmentFileName=segment, chunkId=1) with path /var/folders/f_/6tkk7f6x7377dzmwfsqkdtk00000gq/T/junit11001183003053723613/cache/segment-1 from cache directory. The reason of the deletion is EXPIRED (io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache:111)
java.nio.file.NoSuchFileException: /var/folders/f_/6tkk7f6x7377dzmwfsqkdtk00000gq/T/junit11001183003053723613/cache/segment-1
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
	at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:148)
	at java.base/java.nio.file.Files.readAttributes(Files.java:1851)
	at java.base/java.nio.file.Files.size(Files.java:2468)
	at io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache.lambda$removalListener$0(DiskChunkCache.java:101)
	at com.github.benmanes.caffeine.cache.Async$AsyncEvictionListener.onRemoval(Async.java:117)
	at com.github.benmanes.caffeine.cache.Async$AsyncEvictionListener.onRemoval(Async.java:101)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.notifyEviction(BoundedLocalCache.java:442)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$evictEntry$2(BoundedLocalCache.java:1071)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfPresent(ConcurrentHashMap.java:1828)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.evictEntry(BoundedLocalCache.java:1032)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.expireAfterAccessEntries(BoundedLocalCache.java:939)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.expireAfterAccessEntries(BoundedLocalCache.java:925)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.expireEntries(BoundedLocalCache.java:903)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.maintenance(BoundedLocalCache.java:1721)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.performCleanUp(BoundedLocalCache.java:1660)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache$PerformCleanupTask.run(BoundedLocalCache.java:3886)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
``` 

There seem to be multiple calls to this listener happening concurrently, causing this behavior (first caller to win, and the next one to don't find the file), so an additional handling is has been added. At runtime this exception is swallow by the listener execution, so this is mostly to have better logging when this happens.

This seems to be expected looking at the Caffeine docs:

The RemovalListener states:

> An instance may be called concurrently by multiple threads to process different entries.

Also

> Implementations of this interface should avoid performing blocking calls or synchronizing on shared resources.

