### PR TITLE
fix: exclude unnecessary modules in Caffeine

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,7 +41,10 @@ dependencies {
 
     implementation "com.github.luben:zstd-jni:$zstdVersion"
 
-    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion") {
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+    }
 
     implementation "commons-io:commons-io:$apacheCommonsIOVersion"
     implementation project(':commons')

--- a/storage/gcs/build.gradle
+++ b/storage/gcs/build.gradle
@@ -20,8 +20,12 @@ dependencies {
     implementation project(":storage:core")
 
     implementation ("com.google.cloud:google-cloud-storage:$gcpSdkVersion") {
-        exclude group: "com.google.errorprone"
-        exclude group: "org.checkerframework"
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
+        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+        exclude group: 'com.google.guava', module: 'listenablefuture'
     }
 
     implementation project(":commons")


### PR DESCRIPTION
In the released core zip, we included 
1. caffeine-3.1.8.jar
2. checker-qual-3.37.0.jar
3. error_prone_annotations-2.21.1.jar
From this discussion in Caffeine project: https://github.com/ben-manes/caffeine/issues/300#issuecomment-507292996 . The author of Caffeine project:
 
> checker-qual And errorprone are annotations which Java doesn’t require at runtime unless you reflectively load them when inspecting the methods. Unfortunately other languages will not classload without them, making them required. You can exclude safely in Java.

Since we only use JAVA and it doesn't cause any errors while compiling after excluding them, I think we should remove them from the distribution zip.