### PR TITLE
Avoid hostname errors from s3 integration tests

### DIFF
--- a/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3ErrorMetricsTest.java
+++ b/storage/s3/src/integration-test/java/io/aiven/kafka/tieredstorage/storage/s3/S3ErrorMetricsTest.java
@@ -78,6 +78,7 @@ class S3ErrorMetricsTest {
             "s3.bucket.name", BUCKET_NAME,
             "s3.region", Region.US_EAST_1.id(),
             "s3.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
+            "s3.path.style.access.enabled", "true",
             "aws.credentials.provider.class", AnonymousCredentialsProvider.class.getName()
         );
         storage.configure(configs);
@@ -106,6 +107,7 @@ class S3ErrorMetricsTest {
             "s3.bucket.name", BUCKET_NAME,
             "s3.region", Region.US_EAST_1.id(),
             "s3.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
+            "s3.path.style.access.enabled", "true",
             "aws.credentials.provider.class", AnonymousCredentialsProvider.class.getName()
         );
         storage.configure(configs);
@@ -135,6 +137,7 @@ class S3ErrorMetricsTest {
             "s3.bucket.name", BUCKET_NAME,
             "s3.region", Region.US_EAST_1.id(),
             "s3.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
+            "s3.path.style.access.enabled", "true",
             "s3.api.call.attempt.timeout", 1,
             "aws.credentials.provider.class", AnonymousCredentialsProvider.class.getName()
         );
@@ -164,6 +167,7 @@ class S3ErrorMetricsTest {
             "s3.bucket.name", BUCKET_NAME,
             "s3.region", Region.US_EAST_1.id(),
             "s3.endpoint.url", wmRuntimeInfo.getHttpBaseUrl(),
+            "s3.path.style.access.enabled", "true",
             "aws.credentials.provider.class", AnonymousCredentialsProvider.class.getName()
         );
         storage.configure(configs);


### PR DESCRIPTION
Fixing the s3 integration tests.

The s3 integraion tests are using `s3.bucket.name` set to "test-bucket" and `s3.endpoint.url` set to "http://localhost:...".
Then, the client uses the hostname `test-bucket.localhost`, which causes those tests to fail with UnknownHostException.

```
    Caused by: software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: test-bucket.localhost
        at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:111)
        at software.amazon.awssdk.core.exception.SdkClientException.create(SdkClientException.java:47)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.utils.RetryableStageHelper.setLastException(RetryableStageHelper.java:223)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:83)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        ...
```

In order to avoid this hostname problem, we should set `s3.path.style.access.enabled` to "true" in those tests.
Please have a look.
Thanks.