### PR TITLE
feat: additional configs for caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 target
 docs/_build
 .idea

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -24,6 +24,7 @@
     <suppress checks="ClassFanOutComplexity" files="RemoteStorageManager.java"/>
     <suppress checks="ClassFanOutComplexity" files="ChunkCache.java"/>
     <suppress checks="ClassFanOutComplexity" files="MemorySegmentIndexesCache"/>
+    <suppress checks="ClassFanOutComplexity" files="MemorySegmentManifestCache"/>
     <suppress checks="ClassFanOutComplexity" files="AzureBlobStorage.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="CaffeineStatsCounter.java"/>
     <suppress checks="ClassDataAbstractionCoupling" files="S3StorageConfig.java"/>

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/CacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/CacheConfig.java
@@ -31,6 +31,12 @@ public class CacheConfig extends AbstractConfig {
     private static final String CACHE_RETENTION_CONFIG = "retention.ms";
     private static final String CACHE_RETENTION_DOC = "Cache retention time ms, "
         + "where \"-1\" represents infinite retention";
+    private static final String CACHE_FETCH_THREAD_POOL_SIZE_CONFIG = "fetch.thread.pool.size";
+    private static final String CACHE_FETCH_THREAD_POOL_SIZE_DOC = "Size for the thread pool used to "
+        + "schedule asynchronous fetching tasks, default to number of processors.";
+    private static final String CACHE_FETCH_TIMEOUT_MS_CONFIG = "fetch.timeout.ms";
+    private static final String CACHE_FETCH_TIMEOUT_MS_DOC = "When getting an object from the fetch, "
+        + "how long to wait before timing out. Defaults to 10 sec.";
 
     static final long CACHE_RETENTION_MS_DEFAULT = 600_000;
 
@@ -54,6 +60,22 @@ public class CacheConfig extends AbstractConfig {
             ConfigDef.Range.between(-1L, Long.MAX_VALUE),
             ConfigDef.Importance.MEDIUM,
             CACHE_RETENTION_DOC
+        );
+        configDef.define(
+            CACHE_FETCH_THREAD_POOL_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            0,
+            ConfigDef.Range.between(0, 1024),
+            ConfigDef.Importance.LOW,
+            CACHE_FETCH_THREAD_POOL_SIZE_DOC
+        );
+        configDef.define(
+            CACHE_FETCH_TIMEOUT_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            Duration.ofSeconds(10).toMillis(),
+            ConfigDef.Range.between(1, Long.MAX_VALUE),
+            ConfigDef.Importance.LOW,
+            CACHE_FETCH_TIMEOUT_MS_DOC
         );
         return configDef;
     }
@@ -85,6 +107,18 @@ public class CacheConfig extends AbstractConfig {
             return Optional.empty();
         }
         return Optional.of(Duration.ofMillis(rawValue));
+    }
+
+    public Optional<Integer> threadPoolSize() {
+        final Integer rawValue = getInt(CACHE_FETCH_THREAD_POOL_SIZE_CONFIG);
+        if (rawValue == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(rawValue);
+    }
+
+    public Duration getTimeout() {
+        return Duration.ofMillis(getLong(CACHE_FETCH_TIMEOUT_MS_CONFIG));
     }
 
     public static class Builder {

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/config/CacheConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/config/CacheConfigTest.java
@@ -34,6 +34,9 @@ class CacheConfigTest {
 
         assertThat(config.cacheSize()).isNotPresent();
         assertThat(config.cacheRetention()).hasValue(Duration.ofMinutes(10));
+        // other defaults
+        assertThat(config.threadPoolSize()).isEmpty();
+        assertThat(config.getTimeout()).hasSeconds(10);
     }
 
     @Test
@@ -44,6 +47,9 @@ class CacheConfigTest {
 
         assertThat(config.cacheSize()).isNotPresent();
         assertThat(config.cacheRetention()).hasValue(Duration.ofMinutes(10));
+        // other defaults
+        assertThat(config.threadPoolSize()).isEmpty();
+        assertThat(config.getTimeout()).hasSeconds(10);
     }
 
     @Test
@@ -118,5 +124,17 @@ class CacheConfigTest {
         assertThatThrownBy(() -> CacheConfig.newBuilder(configs).build())
             .isInstanceOf(ConfigException.class)
             .hasMessage("Invalid value -2 for configuration retention.ms: Value must be at least -1");
+    }
+
+    @Test
+    void setOtherConfigs() {
+        final CacheConfig config = CacheConfig.newBuilder(Map.of(
+                "fetch.thread.pool.size", 16,
+                "fetch.timeout.ms", Duration.ofSeconds(20).toMillis()
+            ))
+            .withDefaultSize(-1L)
+            .build();
+        assertThat(config.threadPoolSize()).hasValue(16);
+        assertThat(config.getTimeout()).hasSeconds(20);
     }
 }


### PR DESCRIPTION
Currently the ForkJoinPools used by the fetch caches (chunk, indexes, and manifest) are defined by default. Also, the fetching is timeout by default to 10secs.
This PR aims to introduce thread-pool size and timeout configurations to the cache config to each fetch cache, to allow tuning.