### PR TITLE
feat: bypass chunking when no transformation is requested

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -223,38 +223,38 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
         final long startedMs = time.milliseconds();
 
         try {
-            SegmentEncryptionMetadataV1 encryptionMetadata = null;
             final boolean requiresCompression = requiresCompression(logSegmentData);
 
-            final ChunkIndex chunkIndex;
-            try (final InputStream logSegmentInputStream = Files.newInputStream(logSegmentData.logSegment())) {
-                TransformChunkEnumeration transformEnum = new BaseTransformChunkEnumeration(
-                    logSegmentInputStream, chunkSize);
-                if (requiresCompression) {
-                    transformEnum = new CompressionChunkEnumeration(transformEnum);
-                }
-                if (encryptionEnabled) {
-                    final DataKeyAndAAD dataKeyAndAAD = aesEncryptionProvider.createDataKeyAndAAD();
-                    transformEnum = new EncryptionChunkEnumeration(
-                        transformEnum,
-                        () -> aesEncryptionProvider.encryptionCipher(dataKeyAndAAD));
-                    encryptionMetadata = new SegmentEncryptionMetadataV1(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad);
-                }
-                final TransformFinisher transformFinisher = new TransformFinisher(
-                    transformEnum,
-                    remoteLogSegmentMetadata.segmentSizeInBytes(),
-                    rateLimitingBucket
-                );
-                uploadSegmentLog(remoteLogSegmentMetadata, transformFinisher, customMetadataBuilder);
-                chunkIndex = transformFinisher.chunkIndex();
+            final DataKeyAndAAD maybeEncryptionKey;
+            if (encryptionEnabled) {
+                maybeEncryptionKey = aesEncryptionProvider.createDataKeyAndAAD();
+            } else {
+                maybeEncryptionKey = null;
             }
 
-            final SegmentIndexesV1 segmentIndexes = uploadIndexes(
-                remoteLogSegmentMetadata, logSegmentData, encryptionMetadata, customMetadataBuilder);
-            final SegmentManifest segmentManifest = new SegmentManifestV1(
-                chunkIndex, segmentIndexes, requiresCompression, encryptionMetadata, remoteLogSegmentMetadata);
-            uploadManifest(remoteLogSegmentMetadata, segmentManifest, customMetadataBuilder);
+            final ChunkIndex chunkIndex = uploadSegmentLog(
+                remoteLogSegmentMetadata,
+                logSegmentData,
+                requiresCompression,
+                maybeEncryptionKey,
+                customMetadataBuilder
+            );
 
+            final SegmentIndexesV1 segmentIndexes = uploadIndexes(
+                remoteLogSegmentMetadata,
+                logSegmentData,
+                maybeEncryptionKey,
+                customMetadataBuilder
+            );
+
+            uploadManifest(
+                remoteLogSegmentMetadata,
+                chunkIndex,
+                segmentIndexes,
+                requiresCompression,
+                maybeEncryptionKey,
+                customMetadataBuilder
+            );
         } catch (final Exception e) {
             try {
                 // best effort on removing orphan files
@@ -287,7 +287,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
     SegmentIndexesV1 uploadIndexes(
         final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
         final LogSegmentData segmentData,
-        final SegmentEncryptionMetadataV1 encryptionMeta,
+        final DataKeyAndAAD maybeEncryptionKey,
         final SegmentCustomMetadataBuilder customMetadataBuilder
     ) throws IOException, RemoteStorageException, StorageBackendException {
         final List<InputStream> indexes = new ArrayList<>(IndexType.values().length);
@@ -298,7 +298,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 IndexType.OFFSET,
                 closableInputStreamHolder.add(Files.newInputStream(segmentData.offsetIndex())),
                 indexSize(segmentData.offsetIndex()),
-                encryptionMeta,
+                maybeEncryptionKey,
                 segmentIndexBuilder
             );
             indexes.add(offsetIndex);
@@ -306,7 +306,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 IndexType.TIMESTAMP,
                 closableInputStreamHolder.add(Files.newInputStream(segmentData.timeIndex())),
                 indexSize(segmentData.timeIndex()),
-                encryptionMeta,
+                maybeEncryptionKey,
                 segmentIndexBuilder
             );
             indexes.add(timeIndex);
@@ -314,7 +314,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 IndexType.PRODUCER_SNAPSHOT,
                 closableInputStreamHolder.add(Files.newInputStream(segmentData.producerSnapshotIndex())),
                 indexSize(segmentData.producerSnapshotIndex()),
-                encryptionMeta,
+                maybeEncryptionKey,
                 segmentIndexBuilder
             );
             indexes.add(producerSnapshotIndex);
@@ -322,7 +322,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 IndexType.LEADER_EPOCH,
                 closableInputStreamHolder.add(new ByteBufferInputStream(segmentData.leaderEpochIndex())),
                 segmentData.leaderEpochIndex().remaining(),
-                encryptionMeta,
+                maybeEncryptionKey,
                 segmentIndexBuilder
             );
             indexes.add(leaderEpoch);
@@ -331,7 +331,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                     IndexType.TRANSACTION,
                     closableInputStreamHolder.add(Files.newInputStream(segmentData.transactionIndex().get())),
                     indexSize(segmentData.transactionIndex().get()),
-                    encryptionMeta,
+                    maybeEncryptionKey,
                     segmentIndexBuilder
                 );
                 indexes.add(transactionIndex);
@@ -397,37 +397,71 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
         return requiresCompression;
     }
 
-    void uploadSegmentLog(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
-                          final TransformFinisher transformFinisher,
-                          final SegmentCustomMetadataBuilder customMetadataBuilder)
-        throws IOException, StorageBackendException {
-        final ObjectKey fileKey = objectKeyFactory.key(remoteLogSegmentMetadata, ObjectKeyFactory.Suffix.LOG);
-        try (final var sis = transformFinisher.toInputStream()) {
-            final var bytes = uploader.upload(sis, fileKey);
-            metrics.recordObjectUpload(
-                remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
-                ObjectKeyFactory.Suffix.LOG,
-                bytes
-            );
-            customMetadataBuilder.addUploadResult(ObjectKeyFactory.Suffix.LOG, bytes);
+    ChunkIndex uploadSegmentLog(
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+        final LogSegmentData logSegmentData,
+        final boolean requiresCompression,
+        final DataKeyAndAAD maybeEncryptionKey,
+        final SegmentCustomMetadataBuilder customMetadataBuilder
+    ) throws IOException, StorageBackendException {
+        final var objectKey = objectKeyFactory.key(remoteLogSegmentMetadata, ObjectKeyFactory.Suffix.LOG);
 
-            log.debug("Uploaded segment log for {}, size: {}", remoteLogSegmentMetadata, bytes);
+        try (final var logSegmentInputStream = Files.newInputStream(logSegmentData.logSegment())) {
+            final var transformEnum = transformation(logSegmentInputStream, requiresCompression, maybeEncryptionKey);
+            final TransformFinisher transformFinisher = new TransformFinisher(
+                transformEnum,
+                remoteLogSegmentMetadata.segmentSizeInBytes(),
+                rateLimitingBucket
+            );
+
+            try (final var sis = transformFinisher.toInputStream()) {
+                final var bytes = uploader.upload(sis, objectKey);
+                metrics.recordObjectUpload(
+                    remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
+                    ObjectKeyFactory.Suffix.LOG,
+                    bytes
+                );
+                customMetadataBuilder.addUploadResult(ObjectKeyFactory.Suffix.LOG, bytes);
+
+                log.debug("Uploaded segment log for {}, size: {}", remoteLogSegmentMetadata, bytes);
+            }
+            return transformFinisher.chunkIndex();
         }
+    }
+
+    private TransformChunkEnumeration transformation(
+        final InputStream logSegmentInputStream,
+        final boolean requiresCompression,
+        final DataKeyAndAAD maybeEncryptionKey
+    ) {
+        TransformChunkEnumeration transformEnum = new BaseTransformChunkEnumeration(
+            logSegmentInputStream,
+            chunkSize
+        );
+        if (requiresCompression) {
+            transformEnum = new CompressionChunkEnumeration(transformEnum);
+        }
+        if (encryptionEnabled) {
+            transformEnum = new EncryptionChunkEnumeration(
+                transformEnum,
+                () -> aesEncryptionProvider.encryptionCipher(maybeEncryptionKey)
+            );
+        }
+        return transformEnum;
     }
 
     InputStream transformIndex(final IndexType indexType,
                                final InputStream index,
                                final int size,
-                               final SegmentEncryptionMetadata encryptionMetadata,
+                               final DataKeyAndAAD maybeEncryptionKey,
                                final SegmentIndexesV1Builder segmentIndexBuilder) {
         log.debug("Transforming index {} with size {}", indexType, size);
         if (size > 0) {
             TransformChunkEnumeration transformEnum = new BaseTransformChunkEnumeration(index, size);
             if (encryptionEnabled) {
-                final var dataKeyAndAAD = new DataKeyAndAAD(encryptionMetadata.dataKey(), encryptionMetadata.aad());
                 transformEnum = new EncryptionChunkEnumeration(
                     transformEnum,
-                    () -> aesEncryptionProvider.encryptionCipher(dataKeyAndAAD));
+                    () -> aesEncryptionProvider.encryptionCipher(maybeEncryptionKey));
             }
             final var transformFinisher = new TransformFinisher(transformEnum, size, rateLimitingBucket);
             final var inputStream = transformFinisher.nextElement();
@@ -448,9 +482,25 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
     }
 
     void uploadManifest(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
-                        final SegmentManifest segmentManifest,
-                        final SegmentCustomMetadataBuilder customMetadataBuilder)
-        throws StorageBackendException, IOException {
+                        final ChunkIndex chunkIndex,
+                        final SegmentIndexesV1 segmentIndexes,
+                        final boolean requiresCompression,
+                        final DataKeyAndAAD maybeEncryptionKey,
+                        final SegmentCustomMetadataBuilder customMetadataBuilder
+    ) throws StorageBackendException, IOException {
+        final SegmentEncryptionMetadataV1 maybeEncryptionMetadata;
+        if (maybeEncryptionKey != null) {
+            maybeEncryptionMetadata = new SegmentEncryptionMetadataV1(maybeEncryptionKey);
+        } else {
+            maybeEncryptionMetadata = null;
+        }
+        final SegmentManifest segmentManifest = new SegmentManifestV1(
+            chunkIndex,
+            segmentIndexes,
+            requiresCompression,
+            maybeEncryptionMetadata,
+            remoteLogSegmentMetadata
+        );
         final String manifest = mapper.writeValueAsString(segmentManifest);
         final ObjectKey manifestObjectKey =
             objectKeyFactory.key(remoteLogSegmentMetadata, ObjectKeyFactory.Suffix.MANIFEST);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -413,6 +413,7 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                     remoteLogSegmentMetadata.segmentSizeInBytes()
                 )
                 .withRateLimitingBucket(rateLimitingBucket)
+                .withOriginalFilePath(logSegmentData.logSegment())
                 .build();
 
             try (final var sis = transformFinisher.toInputStream()) {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentEncryptionMetadataV1.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/manifest/SegmentEncryptionMetadataV1.java
@@ -21,6 +21,8 @@ import javax.crypto.SecretKey;
 import java.util.Arrays;
 import java.util.Objects;
 
+import io.aiven.kafka.tieredstorage.security.DataKeyAndAAD;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -35,6 +37,10 @@ public class SegmentEncryptionMetadataV1 implements SegmentEncryptionMetadata {
                                        @JsonProperty(value = "aad", required = true) final byte[] aad) {
         this.dataKey = Objects.requireNonNull(dataKey, "dataKey cannot be null");
         this.aad = Objects.requireNonNull(aad, "aad cannot be null");
+    }
+
+    public SegmentEncryptionMetadataV1(final DataKeyAndAAD dataKeyAndAAD) {
+        this(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad);
     }
 
     @Override

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/BaseDetransformChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/BaseDetransformChunkEnumeration.java
@@ -33,7 +33,8 @@ import io.aiven.kafka.tieredstorage.Chunk;
  * both transformed and not. We rely on this information for determining the transformed chunks borders
  * in the input stream. We also can tell if the input stream has too few bytes.
  *
- * <p>An empty list of chunks means no chunking has been applied to the incoming stream.
+ * <p>An empty list of chunks means no chunking has been applied to the incoming stream
+ * and all content should be returned at once.
  */
 public class BaseDetransformChunkEnumeration implements DetransformChunkEnumeration {
     private final InputStream inputStream;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/BaseTransformChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/BaseTransformChunkEnumeration.java
@@ -32,12 +32,10 @@ public class BaseTransformChunkEnumeration implements TransformChunkEnumeration 
 
     private byte[] chunk = null;
 
-    public BaseTransformChunkEnumeration(final InputStream inputStream) {
-        this.inputStream = Objects.requireNonNull(inputStream, "inputStream cannot be null");
-
-        this.originalChunkSize = 0;
-    }
-
+    /**
+     * @param inputStream       original content
+     * @param originalChunkSize chunk size from the <b>original</b> content. If zero, it disables chunking.
+     */
     public BaseTransformChunkEnumeration(final InputStream inputStream,
                                          final int originalChunkSize) {
         this.inputStream = Objects.requireNonNull(inputStream, "inputStream cannot be null");

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/TransformFinisher.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/TransformFinisher.java
@@ -29,8 +29,6 @@ import io.aiven.kafka.tieredstorage.manifest.index.VariableSizeChunkIndexBuilder
 
 import io.github.bucket4j.Bucket;
 
-// TODO test transforms and detransforms with property-based tests
-
 /**
  * The transformation finisher.
  *
@@ -38,42 +36,51 @@ import io.github.bucket4j.Bucket;
  * so that it could be used in {@link SequenceInputStream}.
  *
  * <p>It's responsible for building the chunk index.
+ * The chunk index is empty (i.e. null) if chunking has been disabled (i.e. chunk size is zero),
+ * but could also have a single chunk if the chunk size is equal or higher to the original file size.
+ * Otherwise, the chunk index will contain more than one chunk.
  */
 public class TransformFinisher implements Enumeration<InputStream> {
     private final TransformChunkEnumeration inner;
     private final AbstractChunkIndexBuilder chunkIndexBuilder;
-    private final int originalFileSize;
     private ChunkIndex chunkIndex = null;
     private final Bucket rateLimitingBucket;
 
-    public TransformFinisher(final TransformChunkEnumeration inner, final Bucket rateLimitingBucket) {
-        this(inner, 0, rateLimitingBucket);
+    public static Builder newBuilder(final TransformChunkEnumeration inner, final int originalFileSize) {
+        return new Builder(inner, originalFileSize);
     }
 
-    public TransformFinisher(
+    private TransformFinisher(
         final TransformChunkEnumeration inner,
+        final boolean chunkingEnabled,
         final int originalFileSize,
         final Bucket rateLimitingBucket
     ) {
         this.inner = Objects.requireNonNull(inner, "inner cannot be null");
-        this.originalFileSize = originalFileSize;
 
-        if (originalFileSize < 0) {
-            throw new IllegalArgumentException(
-                "originalFileSize must be non-negative, " + originalFileSize + " given");
-        }
-
-        final Integer transformedChunkSize = inner.transformedChunkSize();
-        if (originalFileSize == 0) {
-            this.chunkIndexBuilder = null;
-        } else if (transformedChunkSize == null) {
-            this.chunkIndexBuilder = new VariableSizeChunkIndexBuilder(inner.originalChunkSize(), originalFileSize);
-        } else {
-            this.chunkIndexBuilder = new FixedSizeChunkIndexBuilder(
-                inner.originalChunkSize(), originalFileSize, transformedChunkSize);
-        }
-
+        final int originalChunkSize = chunkingEnabled ? inner.originalChunkSize() : originalFileSize;
+        this.chunkIndexBuilder = chunkIndexBuilder(inner, originalChunkSize, originalFileSize);
         this.rateLimitingBucket = rateLimitingBucket;
+    }
+
+    private static AbstractChunkIndexBuilder chunkIndexBuilder(
+        final TransformChunkEnumeration inner,
+        final int originalChunkSize,
+        final int originalFileSize
+    ) {
+        final Integer transformedChunkSize = inner.transformedChunkSize();
+        if (transformedChunkSize == null) {
+            return new VariableSizeChunkIndexBuilder(
+                originalChunkSize,
+                originalFileSize
+            );
+        } else {
+            return new FixedSizeChunkIndexBuilder(
+                originalChunkSize,
+                originalFileSize,
+                transformedChunkSize
+            );
+        }
     }
 
     @Override
@@ -84,19 +91,17 @@ public class TransformFinisher implements Enumeration<InputStream> {
     @Override
     public InputStream nextElement() {
         final var chunk = inner.nextElement();
-        if (chunkIndexBuilder != null) {
-            if (hasMoreElements()) {
-                this.chunkIndexBuilder.addChunk(chunk.length);
-            } else {
-                this.chunkIndex = this.chunkIndexBuilder.finish(chunk.length);
-            }
+        if (hasMoreElements()) {
+            this.chunkIndexBuilder.addChunk(chunk.length);
+        } else {
+            this.chunkIndex = this.chunkIndexBuilder.finish(chunk.length);
         }
 
         return new ByteArrayInputStream(chunk);
     }
 
     public ChunkIndex chunkIndex() {
-        if (chunkIndex == null && originalFileSize > 0) {
+        if (chunkIndex == null) {
             throw new IllegalStateException("Chunk index was not built, was finisher used?");
         }
         return this.chunkIndex;
@@ -108,6 +113,38 @@ public class TransformFinisher implements Enumeration<InputStream> {
             return sequencedInputStream;
         } else {
             return new RateLimitedInputStream(sequencedInputStream, rateLimitingBucket);
+        }
+    }
+
+    public static class Builder {
+        final TransformChunkEnumeration inner;
+        final Integer originalFileSize;
+        boolean chunkingEnabled = true;
+        Bucket rateLimitingBucket;
+
+        public Builder(final TransformChunkEnumeration inner, final int originalFileSize) {
+            this.inner = inner;
+
+            if (originalFileSize < 0) {
+                throw new IllegalArgumentException(
+                    "originalFileSize must be non-negative, " + originalFileSize + " given");
+            }
+
+            this.originalFileSize = originalFileSize;
+        }
+
+        public Builder withRateLimitingBucket(final Bucket rateLimitingBucket) {
+            this.rateLimitingBucket = rateLimitingBucket;
+            return this;
+        }
+
+        public Builder withChunkingDisabled() {
+            this.chunkingEnabled = false;
+            return this;
+        }
+
+        public TransformFinisher build() {
+            return new TransformFinisher(inner, chunkingEnabled, originalFileSize, rateLimitingBucket);
         }
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerTest.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
@@ -265,7 +266,7 @@ class RemoteStorageManagerTest {
         rsm = spy(rsm);
 
         // when first upload fails
-        doThrow(IOException.class).when(rsm).uploadSegmentLog(any(), any(), any());
+        doThrow(IOException.class).when(rsm).uploadSegmentLog(any(), any(), anyBoolean(), any(), any());
 
         assertThatThrownBy(() -> rsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData))
             .isInstanceOf(RemoteStorageException.class)
@@ -275,7 +276,7 @@ class RemoteStorageManagerTest {
         assertThat(remotePartitionPath).doesNotExist();
 
         // fallback to real method
-        doCallRealMethod().when(rsm).uploadSegmentLog(any(), any(), any());
+        doCallRealMethod().when(rsm).uploadSegmentLog(any(), any(), anyBoolean(), any(), any());
 
         // when second upload fails
         doThrow(IOException.class).when(rsm).uploadIndexes(any(), any(), any(), any());
@@ -291,7 +292,7 @@ class RemoteStorageManagerTest {
         doCallRealMethod().when(rsm).uploadIndexes(any(), any(), any(), any());
 
         // when third upload fails
-        doThrow(IOException.class).when(rsm).uploadManifest(any(), any(), any());
+        doThrow(IOException.class).when(rsm).uploadManifest(any(), any(), any(), anyBoolean(), any(), any());
 
         assertThatThrownBy(() -> rsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData))
             .isInstanceOf(RemoteStorageException.class)
@@ -301,7 +302,7 @@ class RemoteStorageManagerTest {
         assertThat(remotePartitionPath).doesNotExist();
 
         // fallback to real method
-        doCallRealMethod().when(rsm).uploadManifest(any(), any(), any());
+        doCallRealMethod().when(rsm).uploadManifest(any(), any(), any(), anyBoolean(), any(), any());
 
         // when all good
         rsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformFinisherTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformFinisherTest.java
@@ -42,7 +42,8 @@ class TransformFinisherTest {
 
     @Test
     void getIndexBeforeUsing() {
-        final TransformFinisher finisher = new TransformFinisher(new FakeDataEnumerator(3), 7, null);
+        final TransformChunkEnumeration enumerator = new FakeDataEnumerator(3);
+        final TransformFinisher finisher = TransformFinisher.newBuilder(enumerator, 7).build();
         assertThatThrownBy(() -> finisher.chunkIndex())
             .isInstanceOf(IllegalStateException.class)
             .hasMessage("Chunk index was not built, was finisher used?");
@@ -50,14 +51,14 @@ class TransformFinisherTest {
 
     @Test
     void nullInnerEnumeration() {
-        assertThatThrownBy(() -> new TransformFinisher(null, 100, null))
+        assertThatThrownBy(() -> TransformFinisher.newBuilder(null, 100).build())
             .isInstanceOf(NullPointerException.class)
             .hasMessage("inner cannot be null");
     }
 
     @Test
     void negativeOriginalFileSize() {
-        assertThatThrownBy(() -> new TransformFinisher(inner, -1, null))
+        assertThatThrownBy(() -> TransformFinisher.newBuilder(inner, -1).build())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("originalFileSize must be non-negative, -1 given");
     }
@@ -66,7 +67,8 @@ class TransformFinisherTest {
     @MethodSource("provideForBuildIndexAndReturnCorrectInputStreams")
     void buildIndexAndReturnCorrectInputStreams(final Integer transformedChunkSize,
                                                 final Class<ChunkIndex> indexType) throws IOException {
-        final TransformFinisher finisher = new TransformFinisher(new FakeDataEnumerator(transformedChunkSize), 7, null);
+        final TransformChunkEnumeration enumerator = new FakeDataEnumerator(transformedChunkSize);
+        final TransformFinisher finisher = TransformFinisher.newBuilder(enumerator, 7).build();
         assertThat(finisher.hasMoreElements()).isTrue();
         assertThat(finisher.nextElement().readAllBytes()).isEqualTo(new byte[] {0, 1, 2});
         assertThat(finisher.hasMoreElements()).isTrue();

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformsEndToEndTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/transform/TransformsEndToEndTest.java
@@ -69,40 +69,49 @@ public class TransformsEndToEndTest extends AesKeyAwareTest {
     }
 
     private void test(final int chunkSize, final boolean compression, final boolean encryption) throws IOException {
-        // Transform.
-        TransformChunkEnumeration transformEnum = new BaseTransformChunkEnumeration(
-            new ByteArrayInputStream(original), chunkSize);
-        if (compression) {
-            transformEnum = new CompressionChunkEnumeration(transformEnum);
-        }
-        if (encryption) {
-            transformEnum = new EncryptionChunkEnumeration(transformEnum, AesKeyAwareTest::encryptionCipherSupplier);
-        }
-        final var transformFinisher = chunkSize == 0
-            ? new TransformFinisher(transformEnum, null)
-            : new TransformFinisher(transformEnum, ORIGINAL_SIZE, null);
-        final byte[] uploadedData;
-        final ChunkIndex chunkIndex;
-        try (final var sis = transformFinisher.toInputStream()) {
-            uploadedData = sis.readAllBytes();
-            chunkIndex = transformFinisher.chunkIndex();
-        }
+        try (final var inputStream = new ByteArrayInputStream(original)) {
+            // Transform.
+            TransformChunkEnumeration transformEnum = new BaseTransformChunkEnumeration(inputStream, chunkSize);
+            if (compression) {
+                transformEnum = new CompressionChunkEnumeration(transformEnum);
+            }
+            if (encryption) {
+                transformEnum = new EncryptionChunkEnumeration(
+                    transformEnum,
+                    AesKeyAwareTest::encryptionCipherSupplier
+                );
+            }
+            final var transformBuilder = TransformFinisher.newBuilder(transformEnum, ORIGINAL_SIZE);
+            if (chunkSize == 0) {
+                transformBuilder.withChunkingDisabled();
+            }
+            final var transformFinisher = transformBuilder.build();
+            final byte[] uploadedData;
+            final ChunkIndex chunkIndex;
+            try (final var sis = transformFinisher.toInputStream()) {
+                uploadedData = sis.readAllBytes();
+                chunkIndex = transformFinisher.chunkIndex();
+            }
 
-        // Detransform.
-        DetransformChunkEnumeration detransformEnum = chunkIndex == null
-            ? new BaseDetransformChunkEnumeration(new ByteArrayInputStream(uploadedData))
-            : new BaseDetransformChunkEnumeration(new ByteArrayInputStream(uploadedData), chunkIndex.chunks());
-        if (encryption) {
-            detransformEnum = new DecryptionChunkEnumeration(
-                detransformEnum, ivSize, AesKeyAwareTest::decryptionCipherSupplier);
-        }
-        if (compression) {
-            detransformEnum = new DecompressionChunkEnumeration(detransformEnum);
-        }
-        final var detransformFinisher = new DetransformFinisher(detransformEnum);
-        try (final var sis = detransformFinisher.toInputStream()) {
-            final byte[] downloaded = sis.readAllBytes();
-            assertThat(downloaded).isEqualTo(original);
+            // Detransform.
+            try (final var uploadedStream = new ByteArrayInputStream(uploadedData)) {
+                DetransformChunkEnumeration detransformEnum = new BaseDetransformChunkEnumeration(
+                    uploadedStream,
+                    chunkIndex.chunks()
+                );
+                if (encryption) {
+                    detransformEnum = new DecryptionChunkEnumeration(
+                        detransformEnum, ivSize, AesKeyAwareTest::decryptionCipherSupplier);
+                }
+                if (compression) {
+                    detransformEnum = new DecompressionChunkEnumeration(detransformEnum);
+                }
+                final var detransformFinisher = new DetransformFinisher(detransformEnum);
+                try (final var sis = detransformFinisher.toInputStream()) {
+                    final byte[] downloaded = sis.readAllBytes();
+                    assertThat(downloaded).isEqualTo(original);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Pass directly the file input stream to the storage layer instead of calculating chunks on the fly. Optimizes for the default configuration (no encryption/compression), and prepares for further passing the path to the storage layer if uploading directly from file is preferred.

It contains a couple of meaningful refactoring to clean up RSM logic and simplify chunking. See commits for further details.