### PR TITLE
refactor: expose configDef() for all cache config sets

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/CacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/CacheConfig.java
@@ -38,59 +38,21 @@ public class CacheConfig extends AbstractConfig {
     private static final String CACHE_FETCH_TIMEOUT_MS_DOC = "When getting an object from the fetch, "
         + "how long to wait before timing out. Defaults to 10 sec.";
 
-    static final long CACHE_RETENTION_MS_DEFAULT = 600_000;
+    public static final long CACHE_RETENTION_MS_DEFAULT = 600_000;
 
-    private static ConfigDef configDef(
+    public CacheConfig(
         final ConfigDef configDef,
-        final Object defaultSize,
-        final long defaultRetentionMs
+        final Map<String, ?> props
     ) {
-        configDef.define(
-            CACHE_SIZE_CONFIG,
-            ConfigDef.Type.LONG,
-            defaultSize,
-            ConfigDef.Range.between(-1L, Long.MAX_VALUE),
-            ConfigDef.Importance.MEDIUM,
-            CACHE_SIZE_DOC
-        );
-        configDef.define(
-            CACHE_RETENTION_CONFIG,
-            ConfigDef.Type.LONG,
-            defaultRetentionMs,
-            ConfigDef.Range.between(-1L, Long.MAX_VALUE),
-            ConfigDef.Importance.MEDIUM,
-            CACHE_RETENTION_DOC
-        );
-        configDef.define(
-            CACHE_FETCH_THREAD_POOL_SIZE_CONFIG,
-            ConfigDef.Type.INT,
-            0,
-            ConfigDef.Range.between(0, 1024),
-            ConfigDef.Importance.LOW,
-            CACHE_FETCH_THREAD_POOL_SIZE_DOC
-        );
-        configDef.define(
-            CACHE_FETCH_TIMEOUT_MS_CONFIG,
-            ConfigDef.Type.LONG,
-            Duration.ofSeconds(10).toMillis(),
-            ConfigDef.Range.between(1, Long.MAX_VALUE),
-            ConfigDef.Importance.LOW,
-            CACHE_FETCH_TIMEOUT_MS_DOC
-        );
-        return configDef;
+        super(configDef, props);
     }
 
-    CacheConfig(
-        final ConfigDef configDef,
-        final Map<String, ?> props,
-        final Object defaultSize,
-        final long defaultRetentionMs
-    ) {
-        super(configDef(configDef, defaultSize, defaultRetentionMs), props);
+    public static DefBuilder defBuilder() {
+        return new DefBuilder();
     }
 
-    public static Builder newBuilder(final Map<String, ?> configs) {
-        return new Builder(configs);
+    public static DefBuilder defBuilder(final ConfigDef baseConfig) {
+        return new DefBuilder(baseConfig);
     }
 
     public Optional<Long> cacheSize() {
@@ -121,27 +83,64 @@ public class CacheConfig extends AbstractConfig {
         return Duration.ofMillis(getLong(CACHE_FETCH_TIMEOUT_MS_CONFIG));
     }
 
-    public static class Builder {
-        private final Map<String, ?> props;
+    public static class DefBuilder {
         private long defaultRetentionMs = CACHE_RETENTION_MS_DEFAULT;
         private Object maybeDefaultSize = NO_DEFAULT_VALUE;
 
-        public Builder(final Map<String, ?> props) {
-            this.props = props;
+        final ConfigDef configDef;
+
+        public DefBuilder() {
+            this.configDef = new ConfigDef();
         }
 
-        public Builder withDefaultSize(final long defaultSize) {
+        public DefBuilder(final ConfigDef baseConfig) {
+            this.configDef = baseConfig;
+        }
+
+        public DefBuilder withDefaultSize(final long defaultSize) {
             this.maybeDefaultSize = defaultSize;
             return this;
         }
 
-        public Builder withDefaultRetentionMs(final long retentionMs) {
+        public DefBuilder withDefaultRetentionMs(final long retentionMs) {
             this.defaultRetentionMs = retentionMs;
             return this;
         }
 
-        public CacheConfig build() {
-            return new CacheConfig(new ConfigDef(), props, maybeDefaultSize, defaultRetentionMs);
+        public ConfigDef build() {
+            configDef.define(
+                CACHE_SIZE_CONFIG,
+                ConfigDef.Type.LONG,
+                maybeDefaultSize,
+                ConfigDef.Range.between(-1L, Long.MAX_VALUE),
+                ConfigDef.Importance.MEDIUM,
+                CACHE_SIZE_DOC
+            );
+            configDef.define(
+                CACHE_RETENTION_CONFIG,
+                ConfigDef.Type.LONG,
+                defaultRetentionMs,
+                ConfigDef.Range.between(-1L, Long.MAX_VALUE),
+                ConfigDef.Importance.MEDIUM,
+                CACHE_RETENTION_DOC
+            );
+            configDef.define(
+                CACHE_FETCH_THREAD_POOL_SIZE_CONFIG,
+                ConfigDef.Type.INT,
+                0,
+                ConfigDef.Range.between(0, 1024),
+                ConfigDef.Importance.LOW,
+                CACHE_FETCH_THREAD_POOL_SIZE_DOC
+            );
+            configDef.define(
+                CACHE_FETCH_TIMEOUT_MS_CONFIG,
+                ConfigDef.Type.LONG,
+                Duration.ofSeconds(10).toMillis(),
+                ConfigDef.Range.between(1, Long.MAX_VALUE),
+                ConfigDef.Importance.LOW,
+                CACHE_FETCH_TIMEOUT_MS_DOC
+            );
+            return configDef;
         }
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/ChunkCacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/ChunkCacheConfig.java
@@ -26,8 +26,8 @@ public class ChunkCacheConfig extends CacheConfig {
         "The amount of data that should be eagerly prefetched and cached";
     private static final int CACHE_PREFETCHING_SIZE_DEFAULT = 0; //TODO find out what it should be
 
-    private static ConfigDef addCacheConfigs(final ConfigDef configDef) {
-        configDef.define(
+    public static final ConfigDef configDef(final ConfigDef baseConfig) {
+        baseConfig.define(
             CACHE_PREFETCH_MAX_SIZE_CONFIG,
             ConfigDef.Type.INT,
             CACHE_PREFETCHING_SIZE_DEFAULT,
@@ -35,11 +35,17 @@ public class ChunkCacheConfig extends CacheConfig {
             ConfigDef.Importance.MEDIUM,
             CACHE_PREFETCH_MAX_SIZE_DOC
         );
-        return configDef;
+        return CacheConfig.defBuilder(baseConfig)
+            .withDefaultRetentionMs(ChunkCacheConfig.CACHE_RETENTION_MS_DEFAULT)
+            .build();
     }
 
     public ChunkCacheConfig(final ConfigDef configDef, final Map<String, ?> props) {
-        super(addCacheConfigs(configDef), props, ConfigDef.NO_DEFAULT_VALUE, CacheConfig.CACHE_RETENTION_MS_DEFAULT);
+        super(configDef, props);
+    }
+
+    public ChunkCacheConfig(final Map<String, ?> props) {
+        super(configDef(new ConfigDef()), props);
     }
 
     public int cachePrefetchingSize() {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/ChunkManagerFactoryConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/ChunkManagerFactoryConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.fetch;
+package io.aiven.kafka.tieredstorage.config;
 
 import java.util.Map;
 
@@ -23,30 +23,30 @@ import org.apache.kafka.common.config.ConfigDef;
 
 import io.aiven.kafka.tieredstorage.config.validators.Subclass;
 import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.MemoryChunkCache;
 
 public class ChunkManagerFactoryConfig extends AbstractConfig {
 
-    protected static final String FETCH_CHUNK_CACHE_PREFIX = "fetch.chunk.cache.";
+    public static final String FETCH_CHUNK_CACHE_PREFIX = "fetch.chunk.cache.";
     public static final String FETCH_CHUNK_CACHE_CONFIG = FETCH_CHUNK_CACHE_PREFIX + "class";
-    private static final String FETCH_CHUNK_CACHE_DOC = "The fetch chunk cache implementation";
+    private static final String FETCH_CHUNK_CACHE_DOC = "Chunk cache implementation. There are 2 implementations "
+        + "included: " + MemoryChunkCache.class.getName() + " and " + DiskChunkCache.class.getName();
 
-    private static final ConfigDef CONFIG;
-
-    static {
-        CONFIG = new ConfigDef();
-
-        CONFIG.define(
-            FETCH_CHUNK_CACHE_CONFIG,
-            ConfigDef.Type.CLASS,
-            null,
-            Subclass.of(ChunkCache.class),
-            ConfigDef.Importance.MEDIUM,
-            FETCH_CHUNK_CACHE_DOC
-        );
+    public static ConfigDef configDef() {
+        return new ConfigDef()
+            .define(
+                FETCH_CHUNK_CACHE_CONFIG,
+                ConfigDef.Type.CLASS,
+                null,
+                Subclass.of(ChunkCache.class),
+                ConfigDef.Importance.MEDIUM,
+                FETCH_CHUNK_CACHE_DOC
+            );
     }
 
     public ChunkManagerFactoryConfig(final Map<?, ?> originals) {
-        super(CONFIG, originals);
+        super(configDef(), originals);
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/DiskChunkCacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/DiskChunkCacheConfig.java
@@ -34,16 +34,17 @@ public class DiskChunkCacheConfig extends ChunkCacheConfig {
     public static final String TEMP_CACHE_DIRECTORY = "temp";
     public static final String CACHE_DIRECTORY = "cache";
 
-    private static ConfigDef configDef() {
-        final ConfigDef configDef = new ConfigDef();
-        configDef.define(
-            CACHE_PATH_CONFIG,
-            ConfigDef.Type.STRING,
-            ConfigDef.NO_DEFAULT_VALUE,
-            ConfigDef.Importance.HIGH,
-            CACHE_PATH_DOC
+    public static ConfigDef configDef() {
+        return configDef(
+            new ConfigDef()
+                .define(
+                    CACHE_PATH_CONFIG,
+                    ConfigDef.Type.STRING,
+                    ConfigDef.NO_DEFAULT_VALUE,
+                    ConfigDef.Importance.HIGH,
+                    CACHE_PATH_DOC
+                )
         );
-        return configDef;
     }
 
     public DiskChunkCacheConfig(final Map<String, ?> props) {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactory.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/ChunkManagerFactory.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.kafka.common.Configurable;
 
+import io.aiven.kafka.tieredstorage.config.ChunkManagerFactoryConfig;
 import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
 import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
 import io.aiven.kafka.tieredstorage.storage.ObjectFetcher;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/MemoryChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/MemoryChunkCache.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
-import org.apache.kafka.common.config.ConfigDef;
-
 import io.aiven.kafka.tieredstorage.config.ChunkCacheConfig;
 import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
 import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
@@ -64,7 +62,7 @@ public class MemoryChunkCache extends ChunkCache<byte[]> {
 
     @Override
     public void configure(final Map<String, ?> configs) {
-        final ChunkCacheConfig config = new ChunkCacheConfig(new ConfigDef(), configs);
+        final ChunkCacheConfig config = new ChunkCacheConfig(configs);
         this.cache = buildCache(config);
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/index/MemorySegmentIndexesCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/index/MemorySegmentIndexesCache.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
 
 import io.aiven.kafka.tieredstorage.config.CacheConfig;
@@ -133,9 +134,13 @@ public class MemorySegmentIndexesCache implements SegmentIndexesCache {
 
     @Override
     public void configure(final Map<String, ?> configs) {
-        final var config = CacheConfig.newBuilder(configs)
+        final var config = new CacheConfig(configDef(), configs);
+        this.cache = buildCache(config);
+    }
+
+    public static ConfigDef configDef() {
+        return CacheConfig.defBuilder()
             .withDefaultSize(DEFAULT_MAX_SIZE_BYTES)
             .build();
-        this.cache = buildCache(config);
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.kafka.common.config.ConfigDef;
+
 import io.aiven.kafka.tieredstorage.config.CacheConfig;
 import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter;
@@ -122,10 +124,14 @@ public class MemorySegmentManifestCache implements SegmentManifestCache {
 
     @Override
     public void configure(final Map<String, ?> configs) {
-        final var config = CacheConfig.newBuilder(configs)
+        final var config = new CacheConfig(configDef(), configs);
+        this.cache = buildCache(config);
+    }
+
+    public static ConfigDef configDef() {
+        return CacheConfig.defBuilder()
             .withDefaultSize(DEFAULT_MAX_SIZE)
             .withDefaultRetentionMs(DEFAULT_RETENTION_MS)
             .build();
-        this.cache = buildCache(config);
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/config/CacheConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/config/CacheConfigTest.java
@@ -30,7 +30,7 @@ class CacheConfigTest {
 
     @Test
     void cacheUnboundedSize() {
-        final CacheConfig config = CacheConfig.newBuilder(Map.of("size", "-1")).build();
+        final CacheConfig config = new CacheConfig(CacheConfig.defBuilder().build(), Map.of("size", "-1"));
 
         assertThat(config.cacheSize()).isNotPresent();
         assertThat(config.cacheRetention()).hasValue(Duration.ofMinutes(10));
@@ -41,9 +41,10 @@ class CacheConfigTest {
 
     @Test
     void cacheUnboundedWithDefaultSize() {
-        final CacheConfig config = CacheConfig.newBuilder(Map.of())
-            .withDefaultSize(-1L)
-            .build();
+        final CacheConfig config = new CacheConfig(
+            CacheConfig.defBuilder().withDefaultSize(-1L).build(),
+            Map.of()
+        );
 
         assertThat(config.cacheSize()).isNotPresent();
         assertThat(config.cacheRetention()).hasValue(Duration.ofMinutes(10));
@@ -54,41 +55,48 @@ class CacheConfigTest {
 
     @Test
     void cacheSizeBounded() {
-        final CacheConfig config = CacheConfig.newBuilder(Map.of("size", "1024")).build();
+        final CacheConfig config = new CacheConfig(
+            CacheConfig.defBuilder().build(),
+            Map.of("size", "1024")
+        );
         assertThat(config.cacheSize()).hasValue(1024L);
     }
 
     @Test
     void cacheSizeBoundedWithDefaultSize() {
-        final CacheConfig config = CacheConfig.newBuilder(Map.of())
-            .withDefaultSize(1024L)
-            .build();
+        final CacheConfig config = new CacheConfig(
+            CacheConfig.defBuilder().withDefaultSize(1024L).build(),
+            Map.of()
+        );
         assertThat(config.cacheSize()).hasValue(1024L);
     }
 
     @Test
     void cacheSizeBoundedWithDefaultRetentionMs() {
-        final CacheConfig config = CacheConfig.newBuilder(Map.of())
-            .withDefaultSize(-1L)
-            .withDefaultRetentionMs(3_600_000L)
-            .build();
+        final CacheConfig config = new CacheConfig(
+            CacheConfig.defBuilder()
+                .withDefaultSize(-1L)
+                .withDefaultRetentionMs(3_600_000L)
+                .build(),
+            Map.of()
+        );
         assertThat(config.cacheRetention()).hasValue(Duration.ofHours(1));
     }
 
     @Test
     void invalidCacheSize() {
-        assertThatThrownBy(() -> CacheConfig.newBuilder(Map.of("size", "-2")).build())
+        assertThatThrownBy(() -> new CacheConfig(CacheConfig.defBuilder().build(), Map.of("size", "-2")))
             .isInstanceOf(ConfigException.class)
             .hasMessage("Invalid value -2 for configuration size: Value must be at least -1");
 
-        assertThatThrownBy(() -> CacheConfig.newBuilder(Map.of()).withDefaultSize(-2L).build())
+        assertThatThrownBy(() -> new CacheConfig(CacheConfig.defBuilder().withDefaultSize(-2L).build(), Map.of()))
             .isInstanceOf(ConfigException.class)
             .hasMessage("Invalid value -2 for configuration size: Value must be at least -1");
     }
 
     @Test
     void cacheSizeUnspecified() {
-        assertThatThrownBy(() -> CacheConfig.newBuilder(Map.of()).build())
+        assertThatThrownBy(() -> new CacheConfig(CacheConfig.defBuilder().build(), Map.of()))
             .isInstanceOf(ConfigException.class)
             .hasMessage("Missing required configuration \"size\" which has no default value.");
     }
@@ -99,9 +107,7 @@ class CacheConfigTest {
             "retention.ms", "-1",
             "size", "-1"
         );
-        final CacheConfig config = CacheConfig.newBuilder(
-            configs
-        ).build();
+        final CacheConfig config = new CacheConfig(CacheConfig.defBuilder().build(), configs);
         assertThat(config.cacheRetention()).isNotPresent();
     }
 
@@ -111,7 +117,7 @@ class CacheConfigTest {
             "retention.ms", "60000",
             "size", "-1"
         );
-        final CacheConfig config = CacheConfig.newBuilder(configs).build();
+        final CacheConfig config = new CacheConfig(CacheConfig.defBuilder().build(), configs);
         assertThat(config.cacheRetention()).hasValue(Duration.ofMillis(60000));
     }
 
@@ -121,19 +127,22 @@ class CacheConfigTest {
             "retention.ms", "-2",
             "size", "-1"
         );
-        assertThatThrownBy(() -> CacheConfig.newBuilder(configs).build())
+        assertThatThrownBy(() -> new CacheConfig(CacheConfig.defBuilder().build(), configs))
             .isInstanceOf(ConfigException.class)
             .hasMessage("Invalid value -2 for configuration retention.ms: Value must be at least -1");
     }
 
     @Test
     void setOtherConfigs() {
-        final CacheConfig config = CacheConfig.newBuilder(Map.of(
+        final CacheConfig config = new CacheConfig(
+            CacheConfig.defBuilder()
+                .withDefaultSize(-1L)
+                .build(), 
+            Map.of(
                 "thread.pool.size", 16,
                 "get.timeout.ms", Duration.ofSeconds(20).toMillis()
-            ))
-            .withDefaultSize(-1L)
-            .build();
+            )
+        );
         assertThat(config.threadPoolSize()).hasValue(16);
         assertThat(config.getTimeout()).hasSeconds(20);
     }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/config/ChunkCacheConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/config/ChunkCacheConfigTest.java
@@ -19,7 +19,6 @@ package io.aiven.kafka.tieredstorage.config;
 import java.time.Duration;
 import java.util.Map;
 
-import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.junit.jupiter.api.Test;
@@ -32,7 +31,6 @@ class ChunkCacheConfigTest {
     @Test
     void defaults() {
         final ChunkCacheConfig config = new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of("size", "-1")
         );
 
@@ -43,7 +41,6 @@ class ChunkCacheConfigTest {
     @Test
     void cacheSizeUnbounded() {
         final ChunkCacheConfig config = new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of("size", "-1")
         );
         assertThat(config.cacheSize()).isEmpty();
@@ -52,7 +49,6 @@ class ChunkCacheConfigTest {
     @Test
     void cacheSizeBounded() {
         final ChunkCacheConfig config = new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of("size", "1024")
         );
         assertThat(config.cacheSize()).hasValue(1024L);
@@ -61,7 +57,6 @@ class ChunkCacheConfigTest {
     @Test
     void invalidCacheSize() {
         assertThatThrownBy(() -> new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of("size", "-2")
         )).isInstanceOf(ConfigException.class)
             .hasMessage("Invalid value -2 for configuration size: Value must be at least -1");
@@ -70,7 +65,6 @@ class ChunkCacheConfigTest {
     @Test
     void cacheSizeUnspecified() {
         assertThatThrownBy(() -> new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of()
         )).isInstanceOf(ConfigException.class)
             .hasMessage("Missing required configuration \"size\" which has no default value.");
@@ -79,7 +73,6 @@ class ChunkCacheConfigTest {
     @Test
     void cacheRetentionForever() {
         final ChunkCacheConfig config = new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of(
                 "retention.ms", "-1",
                 "size", "-1"
@@ -91,7 +84,6 @@ class ChunkCacheConfigTest {
     @Test
     void cacheRetentionLimited() {
         final ChunkCacheConfig config = new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of(
                 "retention.ms", "60000",
                 "size", "-1"
@@ -103,7 +95,6 @@ class ChunkCacheConfigTest {
     @Test
     void invalidRetention() {
         assertThatThrownBy(() -> new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of(
                 "retention.ms", "-2",
                 "size", "-1"
@@ -115,7 +106,6 @@ class ChunkCacheConfigTest {
     @Test
     void invalidPrefetchingSize() {
         assertThatThrownBy(() -> new ChunkCacheConfig(
-            new ConfigDef(),
             Map.of(
                 "size", "-1",
                 "prefetch.max.size", "-1"

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/config/ChunkManagerFactoryConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/config/ChunkManagerFactoryConfigTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.tieredstorage.fetch;
+package io.aiven.kafka.tieredstorage.config;
 
 import java.util.Map;
 


### PR DESCRIPTION
This is needed for documentation purposes (#601), while also improving the cache config builder.