### PR TITLE
refactor: expose core metric names for doc generation 

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
@@ -47,8 +47,8 @@ import com.github.benmanes.caffeine.cache.Scheduler;
 import com.github.benmanes.caffeine.cache.Weigher;
 
 public abstract class ChunkCache<T> implements ChunkManager, Configurable {
-    private static final String METRIC_GROUP = "chunk-cache-metrics";
-    private static final String THREAD_POOL_METRIC_GROUP = "chunk-cache-thread-pool-metrics";
+    public static final String METRIC_GROUP = "chunk-cache-metrics";
+    public static final String THREAD_POOL_METRIC_GROUP = "chunk-cache-thread-pool-metrics";
 
     private final ChunkManager chunkManager;
     private ExecutorService executor;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/index/MemorySegmentIndexesCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/index/MemorySegmentIndexesCache.java
@@ -49,9 +49,10 @@ import org.slf4j.LoggerFactory;
 public class MemorySegmentIndexesCache implements SegmentIndexesCache {
     private static final Logger log = LoggerFactory.getLogger(MemorySegmentIndexesCache.class);
 
+    public static final String METRIC_GROUP = "segment-indexes-cache-metrics";
+    public static final String THREAD_POOL_METRIC_GROUP = "segment-indexes-cache-thread-pool-metrics";
+
     private static final long DEFAULT_MAX_SIZE_BYTES = 10 * 1024 * 1024;
-    private static final String METRIC_GROUP = "segment-indexes-cache-metrics";
-    private static final String THREAD_POOL_METRIC_GROUP = "segment-indexes-cache-thread-pool-metrics";
 
     private final CaffeineStatsCounter statsCounter = new CaffeineStatsCounter(METRIC_GROUP);
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java
@@ -46,8 +46,8 @@ import org.slf4j.LoggerFactory;
 
 public class MemorySegmentManifestCache implements SegmentManifestCache {
     private static final Logger log = LoggerFactory.getLogger(MemorySegmentManifestCache.class);
-    private static final String METRIC_GROUP = "segment-manifest-cache-metrics";
-    private static final String THREAD_POOL_METRIC_GROUP = "segment-manifest-cache-thread-pool-metrics";
+    public static final String METRIC_GROUP = "segment-manifest-cache-metrics";
+    public static final String THREAD_POOL_METRIC_GROUP = "segment-manifest-cache-thread-pool-metrics";
     private static final long DEFAULT_MAX_SIZE = 1000L;
     private static final long DEFAULT_RETENTION_MS = 3_600_000;
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/CaffeineMetricsRegistry.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/CaffeineMetricsRegistry.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metrics;
+
+import java.util.List;
+
+import org.apache.kafka.common.MetricNameTemplate;
+
+public class CaffeineMetricsRegistry {
+    public static final String METRIC_CONTEXT = "aiven.kafka.server.tieredstorage.cache";
+
+    static final String CACHE_HITS = "cache-hits";
+    static final String CACHE_HITS_TOTAL = CACHE_HITS + "-total";
+    static final String CACHE_MISSES = "cache-misses";
+    static final String CACHE_MISSES_TOTAL = CACHE_MISSES + "-total";
+    static final String CACHE_LOAD = "cache-load";
+    static final String CACHE_LOAD_SUCCESS = CACHE_LOAD + "-success";
+    static final String CACHE_LOAD_SUCCESS_TOTAL = CACHE_LOAD_SUCCESS + "-total";
+    static final String CACHE_LOAD_SUCCESS_TIME = CACHE_LOAD_SUCCESS + "-time";
+    static final String CACHE_LOAD_SUCCESS_TIME_TOTAL = CACHE_LOAD_SUCCESS_TIME + "-total";
+    static final String CACHE_LOAD_FAILURE = CACHE_LOAD + "-failure";
+    static final String CACHE_LOAD_FAILURE_TOTAL = CACHE_LOAD_FAILURE + "-total";
+    static final String CACHE_LOAD_FAILURE_TIME = CACHE_LOAD_FAILURE + "-time";
+    static final String CACHE_LOAD_FAILURE_TIME_TOTAL = CACHE_LOAD_FAILURE_TIME + "-total";
+
+    static final String CACHE_EVICTION = "cache-eviction";
+    static final String CACHE_EVICTION_TOTAL = CACHE_EVICTION + "-total";
+    static final String CACHE_EVICTION_WEIGHT = CACHE_EVICTION + "-weight";
+    static final String CACHE_EVICTION_WEIGHT_TOTAL = CACHE_EVICTION_WEIGHT + "-total";
+
+    static final String CACHE_SIZE = "cache-size";
+    static final String CACHE_SIZE_TOTAL = CACHE_SIZE + "-total";
+
+    final String groupName;
+
+    final MetricNameTemplate cacheHitsMetricName;
+    final MetricNameTemplate cacheMissesMetricName;
+    final MetricNameTemplate cacheLoadSuccessMetricName;
+    final MetricNameTemplate cacheLoadSuccessTimeMetricName;
+    final MetricNameTemplate cacheLoadFailureMetricName;
+    final MetricNameTemplate cacheLoadFailureTimeMetricName;
+    final MetricNameTemplate cacheEvictionMetricName;
+    final MetricNameTemplate cacheEvictionByCauseMetricName;
+    final MetricNameTemplate cacheEvictionWeightMetricName;
+    final MetricNameTemplate cacheEvictionWeightByCauseMetricName;
+    final MetricNameTemplate cacheSizeTotalMetricName;
+
+    public CaffeineMetricsRegistry(final String groupName) {
+        this.groupName = groupName;
+        cacheHitsMetricName = new MetricNameTemplate(
+            CACHE_HITS_TOTAL,
+            groupName,
+            "Cache hits"
+        );
+        cacheMissesMetricName = new MetricNameTemplate(
+            CACHE_MISSES_TOTAL,
+            groupName,
+            "Cache misses"
+        );
+        cacheLoadSuccessMetricName = new MetricNameTemplate(
+            CACHE_LOAD_SUCCESS_TOTAL,
+            groupName,
+            "Successful load of a new entry"
+        );
+        cacheLoadSuccessTimeMetricName = new MetricNameTemplate(
+            CACHE_LOAD_SUCCESS_TIME_TOTAL,
+            groupName,
+            "Time to load a new entry"
+        );
+        cacheLoadFailureMetricName = new MetricNameTemplate(
+            CACHE_LOAD_FAILURE_TOTAL,
+            groupName,
+            "Failures to load a new entry"
+        );
+        cacheLoadFailureTimeMetricName = new MetricNameTemplate(
+            CACHE_LOAD_FAILURE_TIME_TOTAL,
+            groupName,
+            "Time when failing to load a new entry"
+        );
+        cacheEvictionMetricName = new MetricNameTemplate(
+            CACHE_EVICTION_TOTAL,
+            groupName,
+            "Eviction of an entry from the cache"
+        );
+        cacheEvictionByCauseMetricName = new MetricNameTemplate(
+            CACHE_EVICTION_TOTAL,
+            groupName,
+            "Eviction of an entry from the cache tagged by cause",
+            "cause"
+        );
+        cacheEvictionWeightMetricName = new MetricNameTemplate(
+            CACHE_EVICTION_WEIGHT_TOTAL,
+            groupName,
+            "Weight of evicted entry"
+        );
+        cacheEvictionWeightByCauseMetricName = new MetricNameTemplate(
+            CACHE_EVICTION_WEIGHT_TOTAL,
+            groupName,
+            "Weight of evicted entry tagged by cause",
+            "cause"
+        );
+        cacheSizeTotalMetricName = new MetricNameTemplate(
+            CACHE_SIZE_TOTAL,
+            groupName,
+            "Estimated number of entries in the cache"
+        );
+    }
+
+    public List<MetricNameTemplate> all() {
+        return List.of(
+            cacheHitsMetricName,
+            cacheMissesMetricName,
+            cacheLoadSuccessMetricName,
+            cacheLoadSuccessTimeMetricName,
+            cacheLoadFailureMetricName,
+            cacheLoadFailureTimeMetricName,
+            cacheEvictionMetricName,
+            cacheEvictionByCauseMetricName,
+            cacheEvictionWeightMetricName,
+            cacheEvictionWeightByCauseMetricName,
+            cacheSizeTotalMetricName
+        );
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/Metrics.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/Metrics.java
@@ -35,6 +35,7 @@ import io.aiven.kafka.tieredstorage.ObjectKeyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.aiven.kafka.tieredstorage.metrics.MetricsRegistry.METRIC_CONTEXT;
 import static io.aiven.kafka.tieredstorage.metrics.MetricsRegistry.OBJECT_UPLOAD;
 import static io.aiven.kafka.tieredstorage.metrics.MetricsRegistry.OBJECT_UPLOAD_BYTES;
 import static io.aiven.kafka.tieredstorage.metrics.MetricsRegistry.SEGMENT_COPY_TIME;
@@ -69,7 +70,7 @@ public class Metrics {
             metricConfig,
             List.of(reporter),
             time,
-            new KafkaMetricsContext("aiven.kafka.server.tieredstorage")
+            new KafkaMetricsContext(METRIC_CONTEXT)
         );
 
         metricsRegistry = new MetricsRegistry();

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/MetricsRegistry.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/MetricsRegistry.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.tieredstorage.metrics;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.common.MetricNameTemplate;
@@ -24,167 +25,415 @@ import org.apache.kafka.common.TopicPartition;
 import io.aiven.kafka.tieredstorage.ObjectKeyFactory;
 
 public class MetricsRegistry {
-
+    public static final String METRIC_CONTEXT = "aiven.kafka.server.tieredstorage";
     static final String METRIC_GROUP = "remote-storage-manager-metrics";
     static final String TAG_NAME_OBJECT_TYPE = "object-type";
     static final String[] OBJECT_TYPE_TAG_NAMES = {TAG_NAME_OBJECT_TYPE};
     static final String TAG_NAME_TOPIC = "topic";
     static final String[] TOPIC_TAG_NAMES = {TAG_NAME_TOPIC};
-    static final String[] TOPIC_AND_OBJECT_TYPE_TAG_NAMES = {TAG_NAME_TOPIC, TAG_NAME_OBJECT_TYPE};
+    static final String[] TOPIC_OBJECT_TYPE_TAG_NAMES = {TAG_NAME_TOPIC, TAG_NAME_OBJECT_TYPE};
     static final String TAG_NAME_PARTITION = "partition";
     static final String[] TOPIC_PARTITION_TAG_NAMES = {TAG_NAME_TOPIC, TAG_NAME_PARTITION};
-    static final String[] TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES =
+    static final String[] TOPIC_PARTITION_OBJECT_TYPE_TAG_NAMES =
         {TAG_NAME_TOPIC, TAG_NAME_PARTITION, TAG_NAME_OBJECT_TYPE};
+
+    private static final String RATE_DOC_PREFIX = "Rate of ";
+    private static final String TOTAL_DOC_PREFIX = "Total number of ";
+    private static final String AVG_DOC_PREFIX = "Average ";
+    private static final String MAX_DOC_PREFIX = "Maximum ";
+    private static final String BY_TOPIC_DOC_SUFFIX = " tagged by topic";
+    private static final String BY_TOPIC_PARTITION_DOC_SUFFIX = " tagged by topic and partition";
+    private static final String BY_OBJECT_TYPE_DOC_SUFFIX = " tagged by object type";
+    private static final String BY_TOPIC_OBJECT_TYPE_DOC_SUFFIX = " tagged by topic and object type";
+    private static final String BY_TOPIC_PARTITION_OBJECT_TYPE_DOC_SUFFIX = " tagged by topic, "
+        + "partition and object type";
 
     // Segment copy metric names
     static final String SEGMENT_COPY = "segment-copy";
     static final String SEGMENT_COPY_TIME = SEGMENT_COPY + "-time";
+    static final String SEGMENT_COPY_TIME_DOC = "time spent processing and uploading a log segment and indexes";
     static final String SEGMENT_COPY_TIME_AVG = SEGMENT_COPY_TIME + "-avg";
-    final MetricNameTemplate segmentCopyTimeAvg = new MetricNameTemplate(SEGMENT_COPY_TIME_AVG, METRIC_GROUP, "");
-    final MetricNameTemplate segmentCopyTimeAvgByTopic =
-        new MetricNameTemplate(SEGMENT_COPY_TIME_AVG, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentCopyTimeAvgByTopicPartition =
-        new MetricNameTemplate(SEGMENT_COPY_TIME_AVG, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+
+    final MetricNameTemplate segmentCopyTimeAvg = new MetricNameTemplate(
+        SEGMENT_COPY_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + SEGMENT_COPY_TIME_DOC
+    );
+    final MetricNameTemplate segmentCopyTimeAvgByTopic = new MetricNameTemplate(
+        SEGMENT_COPY_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + SEGMENT_COPY_TIME_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentCopyTimeAvgByTopicPartition = new MetricNameTemplate(
+        SEGMENT_COPY_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + SEGMENT_COPY_TIME_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
+
     static final String SEGMENT_COPY_TIME_MAX = SEGMENT_COPY_TIME + "-max";
-    final MetricNameTemplate segmentCopyTimeMax = new MetricNameTemplate(SEGMENT_COPY_TIME_MAX, METRIC_GROUP, "");
-    final MetricNameTemplate segmentCopyTimeMaxByTopic =
-        new MetricNameTemplate(SEGMENT_COPY_TIME_MAX, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentCopyTimeMaxByTopicPartition =
-        new MetricNameTemplate(SEGMENT_COPY_TIME_MAX, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+
+    final MetricNameTemplate segmentCopyTimeMax = new MetricNameTemplate(
+        SEGMENT_COPY_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + SEGMENT_COPY_TIME_DOC
+    );
+    final MetricNameTemplate segmentCopyTimeMaxByTopic = new MetricNameTemplate(
+        SEGMENT_COPY_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + SEGMENT_COPY_TIME_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentCopyTimeMaxByTopicPartition = new MetricNameTemplate(
+        SEGMENT_COPY_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + SEGMENT_COPY_TIME_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
 
     // Segment delete metric names
     static final String SEGMENT_DELETE = "segment-delete";
     static final String SEGMENT_DELETE_RATE = SEGMENT_DELETE + "-rate";
-    final MetricNameTemplate segmentDeleteRequestsRate = new MetricNameTemplate(SEGMENT_DELETE_RATE, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteRequestsRateByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteRequestsRateByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    static final String SEGMENT_DELETE_DOC = "delete remote segment operations, including all its objects";
+    final MetricNameTemplate segmentDeleteRequestsRate = new MetricNameTemplate(
+        SEGMENT_DELETE_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_DOC
+    );
+    final MetricNameTemplate segmentDeleteRequestsRateByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteRequestsRateByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_TOTAL = SEGMENT_DELETE + "-total";
-    final MetricNameTemplate segmentDeleteRequestsTotal =
-        new MetricNameTemplate(SEGMENT_DELETE_TOTAL, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteRequestsTotalByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteRequestsTotalByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteRequestsTotal = new MetricNameTemplate(
+        SEGMENT_DELETE_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_DOC
+    );
+    final MetricNameTemplate segmentDeleteRequestsTotalByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteRequestsTotalByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_BYTES = SEGMENT_DELETE + "-bytes";
+    static final String SEGMENT_DELETE_BYTES_DOC = "deleted number of bytes estimated from segment size";
     static final String SEGMENT_DELETE_BYTES_RATE = SEGMENT_DELETE_BYTES + "-rate";
-    final MetricNameTemplate segmentDeleteBytesRate =
-        new MetricNameTemplate(SEGMENT_DELETE_BYTES_RATE, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteBytesRateByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_BYTES_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteBytesRateByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_BYTES_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteBytesRate = new MetricNameTemplate(
+        SEGMENT_DELETE_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_BYTES_DOC
+    );
+    final MetricNameTemplate segmentDeleteBytesRateByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_BYTES_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteBytesRateByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_BYTES_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_BYTES_TOTAL = SEGMENT_DELETE_BYTES + "-total";
-    final MetricNameTemplate segmentDeleteBytesTotal =
-        new MetricNameTemplate(SEGMENT_DELETE_BYTES_TOTAL, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteBytesTotalByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteBytesTotalByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteBytesTotal = new MetricNameTemplate(
+        SEGMENT_DELETE_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_BYTES_DOC
+    );
+    final MetricNameTemplate segmentDeleteBytesTotalByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_BYTES_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteBytesTotalByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_BYTES_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_TIME = SEGMENT_DELETE + "-time";
+    static final String SEGMENT_DELETE_TIME_DOC = "time spent deleting log segment and indexes";
     static final String SEGMENT_DELETE_TIME_AVG = SEGMENT_DELETE_TIME + "-avg";
-    final MetricNameTemplate segmentDeleteTimeAvg = new MetricNameTemplate(SEGMENT_DELETE_TIME_AVG, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteTimeAvgByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_TIME_AVG, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteTimeAvgByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_TIME_AVG, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteTimeAvg = new MetricNameTemplate(
+        SEGMENT_DELETE_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + SEGMENT_DELETE_TIME_DOC
+    );
+    final MetricNameTemplate segmentDeleteTimeAvgByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + SEGMENT_DELETE_TIME_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteTimeAvgByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + SEGMENT_DELETE_TIME_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_TIME_MAX = SEGMENT_DELETE_TIME + "-max";
-    final MetricNameTemplate segmentDeleteTimeMax = new MetricNameTemplate(SEGMENT_DELETE_TIME_MAX, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteTimeMaxByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_TIME_MAX, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteTimeMaxByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_TIME_MAX, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteTimeMax = new MetricNameTemplate(
+        SEGMENT_DELETE_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + SEGMENT_DELETE_TIME_DOC
+    );
+    final MetricNameTemplate segmentDeleteTimeMaxByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + SEGMENT_DELETE_TIME_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteTimeMaxByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + SEGMENT_DELETE_TIME_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_ERRORS = SEGMENT_DELETE + "-errors";
+    static final String SEGMENT_DELETE_ERRORS_DOC = "errors during remote log segment deletion";
     static final String SEGMENT_DELETE_ERRORS_RATE = SEGMENT_DELETE_ERRORS + "-rate";
-    final MetricNameTemplate segmentDeleteErrorsRate =
-        new MetricNameTemplate(SEGMENT_DELETE_ERRORS_RATE, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteErrorsRateByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_ERRORS_RATE, METRIC_GROUP, "",
-            TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteErrorsRateByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_ERRORS_RATE, METRIC_GROUP, "",
-            TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteErrorsRate = new MetricNameTemplate(
+        SEGMENT_DELETE_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_ERRORS_DOC
+    );
+    final MetricNameTemplate segmentDeleteErrorsRateByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_ERRORS_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteErrorsRateByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_DELETE_ERRORS_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
     static final String SEGMENT_DELETE_ERRORS_TOTAL = SEGMENT_DELETE_ERRORS + "-total";
-    final MetricNameTemplate segmentDeleteErrorsTotal =
-        new MetricNameTemplate(SEGMENT_DELETE_ERRORS_TOTAL, METRIC_GROUP, "");
-    final MetricNameTemplate segmentDeleteErrorsTotalByTopic =
-        new MetricNameTemplate(SEGMENT_DELETE_ERRORS_TOTAL, METRIC_GROUP, "",
-            TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentDeleteErrorsTotalByTopicPartition =
-        new MetricNameTemplate(SEGMENT_DELETE_ERRORS_TOTAL, METRIC_GROUP, "",
-            TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentDeleteErrorsTotal = new MetricNameTemplate(
+        SEGMENT_DELETE_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_ERRORS_DOC
+    );
+    final MetricNameTemplate segmentDeleteErrorsTotalByTopic = new MetricNameTemplate(
+        SEGMENT_DELETE_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_ERRORS_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentDeleteErrorsTotalByTopicPartition = new MetricNameTemplate(
+        SEGMENT_DELETE_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_DELETE_ERRORS_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
 
     // Segment fetch metric names
     static final String SEGMENT_FETCH = "segment-fetch";
+    static final String SEGMENT_FETCH_REQUESTED_BYTES_DOC = "bytes requested by broker, "
+        + "not necessarily the amount to be consumed by fetcher";
     static final String SEGMENT_FETCH_REQUESTED_BYTES = SEGMENT_FETCH + "-requested-bytes";
     static final String SEGMENT_FETCH_REQUESTED_BYTES_RATE = SEGMENT_FETCH_REQUESTED_BYTES + "-rate";
-    final MetricNameTemplate segmentFetchRequestedBytesRate =
-        new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_RATE, METRIC_GROUP, "");
-    final MetricNameTemplate segmentFetchRequestedBytesRateByTopic =
-        new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentFetchRequestedBytesRateByTopicPartition =
-        new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentFetchRequestedBytesRate = new MetricNameTemplate(
+        SEGMENT_FETCH_REQUESTED_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_FETCH_REQUESTED_BYTES_DOC
+    );
+    final MetricNameTemplate segmentFetchRequestedBytesRateByTopic = new MetricNameTemplate(
+        SEGMENT_FETCH_REQUESTED_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_FETCH_REQUESTED_BYTES_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES);
+    final MetricNameTemplate segmentFetchRequestedBytesRateByTopicPartition = new MetricNameTemplate(
+        SEGMENT_FETCH_REQUESTED_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SEGMENT_FETCH_REQUESTED_BYTES_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES);
     static final String SEGMENT_FETCH_REQUESTED_BYTES_TOTAL = SEGMENT_FETCH_REQUESTED_BYTES + "-total";
-    final MetricNameTemplate segmentFetchRequestedBytesTotal =
-        new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_TOTAL, METRIC_GROUP, "");
-    final MetricNameTemplate segmentFetchRequestedBytesTotalByTopic =
-        new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate segmentFetchRequestedBytesTotalByTopicPartition =
-        new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate segmentFetchRequestedBytesTotal = new MetricNameTemplate(
+        SEGMENT_FETCH_REQUESTED_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_FETCH_REQUESTED_BYTES_DOC
+    );
+    final MetricNameTemplate segmentFetchRequestedBytesTotalByTopic = new MetricNameTemplate(
+        SEGMENT_FETCH_REQUESTED_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_FETCH_REQUESTED_BYTES_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate segmentFetchRequestedBytesTotalByTopicPartition = new MetricNameTemplate(
+        SEGMENT_FETCH_REQUESTED_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SEGMENT_FETCH_REQUESTED_BYTES_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
 
     // Object upload metrics
     static final String OBJECT_UPLOAD = "object-upload";
+    static final String OBJECT_UPLOAD_DOC = "upload to a storage backend operations";
     static final String OBJECT_UPLOAD_RATE = OBJECT_UPLOAD + "-rate";
-    final MetricNameTemplate objectUploadRequestsRate = new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "");
-    final MetricNameTemplate objectUploadRequestsRateByObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsRateByTopic =
-        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsRateByTopicAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsRateByTopicPartition =
-        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsRateByTopicPartitionAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsRate = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC
+    );
+    final MetricNameTemplate objectUploadRequestsRateByTopic = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsRateByTopicPartition = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsRateByObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_OBJECT_TYPE_DOC_SUFFIX,
+        OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsRateByTopicAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsRateByTopicPartitionAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_PARTITION_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_PARTITION_OBJECT_TYPE_TAG_NAMES
+    );
     static final String OBJECT_UPLOAD_TOTAL = OBJECT_UPLOAD + "-total";
-    final MetricNameTemplate objectUploadRequestsTotal = new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "");
-    final MetricNameTemplate objectUploadRequestsTotalByObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsTotalByTopic =
-        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsTotalByTopicAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsTotalByTopicPartition =
-        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
-    final MetricNameTemplate objectUploadRequestsTotalByTopicPartitionAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsTotal = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_DOC
+    );
+    final MetricNameTemplate objectUploadRequestsTotalByTopic = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsTotalByTopicPartition = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsTotalByObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_OBJECT_TYPE_DOC_SUFFIX,
+        OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsTotalByTopicAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_DOC_SUFFIX + " and object type",
+        TOPIC_OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadRequestsTotalByTopicPartitionAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_DOC + BY_TOPIC_PARTITION_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_PARTITION_OBJECT_TYPE_TAG_NAMES
+    );
     static final String OBJECT_UPLOAD_BYTES = OBJECT_UPLOAD + "-bytes";
+    static final String OBJECT_UPLOAD_BYTES_DOC = "bytes uploaded to a storage backend";
     static final String OBJECT_UPLOAD_BYTES_RATE = OBJECT_UPLOAD_BYTES + "-rate";
-    final MetricNameTemplate objectUploadBytesRate = new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "");
-    final MetricNameTemplate objectUploadBytesRateByObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesRateByTopic =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesRateByTopicAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesRateByTopicPartition =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesRateByTopicPartitionAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesRate = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC
+    );
+    final MetricNameTemplate objectUploadBytesRateByTopic = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesRateByTopicPartition = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesRateByObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_OBJECT_TYPE_DOC_SUFFIX,
+        OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesRateByTopicAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesRateByTopicPartitionAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_PARTITION_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_PARTITION_OBJECT_TYPE_TAG_NAMES
+    );
     public static final String OBJECT_UPLOAD_BYTES_TOTAL = OBJECT_UPLOAD_BYTES + "-total";
-    final MetricNameTemplate objectUploadBytesTotal =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "");
-    final MetricNameTemplate objectUploadBytesTotalByObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesTotalByTopic =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesTotalByTopicAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesTotalByTopicPartition =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
-    final MetricNameTemplate objectUploadBytesTotalByTopicPartitionAndObjectType =
-        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesTotal = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC
+    );
+    final MetricNameTemplate objectUploadBytesTotalByTopic = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_DOC_SUFFIX,
+        TOPIC_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesTotalByTopicPartition = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_PARTITION_DOC_SUFFIX,
+        TOPIC_PARTITION_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesTotalByObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_OBJECT_TYPE_DOC_SUFFIX,
+        OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesTotalByTopicAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_OBJECT_TYPE_TAG_NAMES
+    );
+    final MetricNameTemplate objectUploadBytesTotalByTopicPartitionAndObjectType = new MetricNameTemplate(
+        OBJECT_UPLOAD_BYTES_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_UPLOAD_BYTES_DOC + BY_TOPIC_PARTITION_OBJECT_TYPE_DOC_SUFFIX,
+        TOPIC_PARTITION_OBJECT_TYPE_TAG_NAMES
+    );
 
     public static String sensorName(final String name) {
         return name;
@@ -251,5 +500,71 @@ public class MetricsRegistry {
 
     static Map<String, String> objectTypeTags(final ObjectKeyFactory.Suffix suffix) {
         return Map.of(TAG_NAME_OBJECT_TYPE, suffix.value);
+    }
+
+    public Iterable<MetricNameTemplate> all() {
+        return List.of(
+            // segment copy
+            segmentCopyTimeAvg,
+            segmentCopyTimeAvgByTopic,
+            segmentCopyTimeAvgByTopicPartition,
+            segmentCopyTimeMax,
+            segmentCopyTimeMaxByTopic,
+            segmentCopyTimeMaxByTopicPartition,
+            // segment delete
+            segmentDeleteRequestsRate,
+            segmentDeleteRequestsRateByTopic,
+            segmentDeleteRequestsRateByTopicPartition,
+            segmentDeleteRequestsTotal,
+            segmentDeleteRequestsTotalByTopic,
+            segmentDeleteRequestsTotalByTopicPartition,
+            segmentDeleteBytesTotal,
+            segmentDeleteBytesTotalByTopic,
+            segmentDeleteBytesTotalByTopicPartition,
+            segmentDeleteTimeAvg,
+            segmentDeleteTimeAvgByTopic,
+            segmentDeleteTimeAvgByTopicPartition,
+            segmentDeleteTimeMax,
+            segmentDeleteTimeMaxByTopic,
+            segmentDeleteTimeMaxByTopicPartition,
+            segmentDeleteErrorsRate,
+            segmentDeleteErrorsRateByTopic,
+            segmentDeleteErrorsRateByTopicPartition,
+            segmentDeleteErrorsTotal,
+            segmentDeleteErrorsTotalByTopic,
+            segmentDeleteErrorsTotalByTopicPartition,
+            // segment fetch
+            segmentFetchRequestedBytesRate,
+            segmentFetchRequestedBytesRateByTopic,
+            segmentFetchRequestedBytesRateByTopicPartition,
+            segmentFetchRequestedBytesTotal,
+            segmentFetchRequestedBytesTotalByTopic,
+            segmentFetchRequestedBytesTotalByTopicPartition,
+            // object upload
+            objectUploadRequestsRate,
+            objectUploadRequestsRateByTopic,
+            objectUploadRequestsRateByTopicPartition,
+            objectUploadRequestsRateByObjectType,
+            objectUploadRequestsRateByTopicAndObjectType,
+            objectUploadRequestsRateByTopicPartitionAndObjectType,
+            objectUploadRequestsTotal,
+            objectUploadRequestsTotalByTopic,
+            objectUploadRequestsTotalByTopicPartition,
+            objectUploadRequestsTotalByObjectType,
+            objectUploadRequestsTotalByTopicAndObjectType,
+            objectUploadRequestsTotalByTopicPartitionAndObjectType,
+            objectUploadBytesRate,
+            objectUploadBytesRateByTopic,
+            objectUploadBytesRateByTopicPartition,
+            objectUploadBytesRateByObjectType,
+            objectUploadBytesRateByTopicAndObjectType,
+            objectUploadBytesRateByTopicPartitionAndObjectType,
+            objectUploadBytesTotal,
+            objectUploadBytesTotalByTopic,
+            objectUploadBytesTotalByTopicPartition,
+            objectUploadBytesTotalByObjectType,
+            objectUploadBytesTotalByTopicAndObjectType,
+            objectUploadBytesTotalByTopicPartitionAndObjectType
+        );
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/ThreadPoolMonitor.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/ThreadPoolMonitor.java
@@ -28,24 +28,19 @@ import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.ACTIVE_THREADS;
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.METRIC_CONFIG;
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.PARALLELISM;
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.POOL_SIZE;
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.QUEUED_TASK_COUNT;
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.RUNNING_THREADS;
+import static io.aiven.kafka.tieredstorage.metrics.ThreadPoolMonitorMetricsRegistry.STEAL_TASK_COUNT;
+
 public class ThreadPoolMonitor {
     // only fork-join pool is supported; but could be extended to other fixed-sized pools
     final ForkJoinPool pool;
     private final Metrics metrics;
     String groupName;
-
-    private static final String ACTIVE_THREADS = "active-thread-count";
-    private static final String ACTIVE_THREADS_TOTAL = ACTIVE_THREADS + "-total";
-    private static final String RUNNING_THREADS = "running-thread-count";
-    private static final String RUNNING_THREADS_TOTAL = RUNNING_THREADS + "-total";
-    private static final String POOL_SIZE = "pool-size";
-    private static final String POOL_SIZE_TOTAL = POOL_SIZE + "-total";
-    private static final String PARALLELISM = "parallelism";
-    private static final String PARALLELISM_TOTAL = PARALLELISM + "-total";
-    private static final String QUEUED_TASK_COUNT = "queued-task-count";
-    private static final String QUEUED_TASK_COUNT_TOTAL = QUEUED_TASK_COUNT + "-total";
-    private static final String STEAL_TASK_COUNT = "steal-task-count";
-    private static final String STEAL_TASK_COUNT_TOTAL = STEAL_TASK_COUNT + "-total";
 
     public ThreadPoolMonitor(final String groupName, final ExecutorService pool) {
         this.groupName = groupName;
@@ -57,21 +52,20 @@ public class ThreadPoolMonitor {
         final JmxReporter reporter = new JmxReporter();
         metrics = new org.apache.kafka.common.metrics.Metrics(
             new MetricConfig(), List.of(reporter), Time.SYSTEM,
-            new KafkaMetricsContext("aiven.kafka.server.tieredstorage.thread-pool")
+            new KafkaMetricsContext(METRIC_CONFIG)
         );
-
-        registerSensor(ACTIVE_THREADS_TOTAL, ACTIVE_THREADS, this::activeThreadCount);
-        registerSensor(RUNNING_THREADS_TOTAL, RUNNING_THREADS, this::runningThreadCount);
-        registerSensor(POOL_SIZE_TOTAL, POOL_SIZE, this::poolSize);
-        registerSensor(PARALLELISM_TOTAL, PARALLELISM, this::parallelism);
-        registerSensor(QUEUED_TASK_COUNT_TOTAL, QUEUED_TASK_COUNT, this::queuedTaskCount);
-        registerSensor(STEAL_TASK_COUNT_TOTAL, STEAL_TASK_COUNT, this::stealTaskCount);
+        final var metricsRegistry = new ThreadPoolMonitorMetricsRegistry(groupName);
+        registerSensor(metricsRegistry.activeThreadsTotalMetricName, ACTIVE_THREADS, this::activeThreadCount);
+        registerSensor(metricsRegistry.runningThreadsTotalMetricName, RUNNING_THREADS, this::runningThreadCount);
+        registerSensor(metricsRegistry.poolSizeTotalMetricName, POOL_SIZE, this::poolSize);
+        registerSensor(metricsRegistry.parallelismTotalMetricName, PARALLELISM, this::parallelism);
+        registerSensor(metricsRegistry.queuedTaskCountTotalMetricName, QUEUED_TASK_COUNT, this::queuedTaskCount);
+        registerSensor(metricsRegistry.stealTaskCountTotalMetricName, STEAL_TASK_COUNT, this::stealTaskCount);
     }
 
-    void registerSensor(final String metricName, final String sensorName, final Supplier<Long> supplier) {
-        final var name = new MetricNameTemplate(metricName, groupName, "");
+    void registerSensor(final MetricNameTemplate metricName, final String sensorName, final Supplier<Long> supplier) {
         new SensorProvider(metrics, sensorName)
-            .with(name, new MeasurableValue(supplier))
+            .with(metricName, new MeasurableValue(supplier))
             .get();
     }
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/ThreadPoolMonitorMetricsRegistry.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/ThreadPoolMonitorMetricsRegistry.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.metrics;
+
+import java.util.List;
+
+import org.apache.kafka.common.MetricNameTemplate;
+
+public class ThreadPoolMonitorMetricsRegistry {
+    public static final String METRIC_CONFIG = "aiven.kafka.server.tieredstorage.thread-pool";
+
+    static final String ACTIVE_THREADS = "active-thread-count";
+    static final String ACTIVE_THREADS_TOTAL = ACTIVE_THREADS + "-total";
+    static final String ACTIVE_THREADS_TOTAL_DOC = "Number of threads currently executing tasks";
+    static final String RUNNING_THREADS = "running-thread-count";
+    static final String RUNNING_THREADS_TOTAL = RUNNING_THREADS + "-total";
+    static final String RUNNING_THREADS_TOTAL_DOC = "Number of worker threads "
+        + "that are not blocked waiting to join tasks or for other managed synchronization";
+    static final String POOL_SIZE = "pool-size";
+    static final String POOL_SIZE_TOTAL = POOL_SIZE + "-total";
+    static final String POOL_SIZE_TOTAL_DOC = "Current number of threads in the pool";
+    static final String PARALLELISM = "parallelism";
+    static final String PARALLELISM_TOTAL = PARALLELISM + "-total";
+    static final String PARALLELISM_TOTAL_DOC = "Targeted parallelism level of the pool";
+    static final String QUEUED_TASK_COUNT = "queued-task-count";
+    static final String QUEUED_TASK_COUNT_TOTAL = QUEUED_TASK_COUNT + "-total";
+    static final String QUEUED_TASK_COUNT_TOTAL_DOC = "Tasks submitted to the pool "
+        + "that have not yet begun executing.";
+    static final String STEAL_TASK_COUNT = "steal-task-count";
+    static final String STEAL_TASK_COUNT_TOTAL = STEAL_TASK_COUNT + "-total";
+    static final String STEAL_TASK_COUNT_TOTAL_DOC = "Number of tasks stolen from one thread's work queue by another";
+
+    final String groupName;
+    final MetricNameTemplate activeThreadsTotalMetricName;
+    final MetricNameTemplate runningThreadsTotalMetricName;
+    final MetricNameTemplate poolSizeTotalMetricName;
+    final MetricNameTemplate parallelismTotalMetricName;
+    final MetricNameTemplate queuedTaskCountTotalMetricName;
+    final MetricNameTemplate stealTaskCountTotalMetricName;
+
+    public ThreadPoolMonitorMetricsRegistry(final String groupName) {
+        this.groupName = groupName;
+        activeThreadsTotalMetricName = new MetricNameTemplate(
+            ACTIVE_THREADS_TOTAL,
+            groupName,
+            ACTIVE_THREADS_TOTAL_DOC
+        );
+        runningThreadsTotalMetricName = new MetricNameTemplate(
+            RUNNING_THREADS_TOTAL,
+            groupName,
+            RUNNING_THREADS_TOTAL_DOC
+        );
+        poolSizeTotalMetricName = new MetricNameTemplate(
+            POOL_SIZE_TOTAL,
+            groupName,
+            POOL_SIZE_TOTAL_DOC
+        );
+        parallelismTotalMetricName = new MetricNameTemplate(
+            PARALLELISM_TOTAL,
+            groupName,
+            PARALLELISM_TOTAL_DOC
+        );
+        queuedTaskCountTotalMetricName = new MetricNameTemplate(
+            QUEUED_TASK_COUNT_TOTAL,
+            groupName,
+            QUEUED_TASK_COUNT_TOTAL_DOC
+        );
+        stealTaskCountTotalMetricName = new MetricNameTemplate(
+            STEAL_TASK_COUNT_TOTAL,
+            groupName,
+            STEAL_TASK_COUNT_TOTAL_DOC
+        );
+    }
+
+    public List<MetricNameTemplate> all() {
+        return List.of(
+            activeThreadsTotalMetricName,
+            runningThreadsTotalMetricName,
+            poolSizeTotalMetricName,
+            parallelismTotalMetricName,
+            queuedTaskCountTotalMetricName,
+            stealTaskCountTotalMetricName
+        );
+    }
+}


### PR DESCRIPTION
Add a metric registry for Caching and Thread Pool metrics, document metrics, and expose metric name templates to be used on documentation generation.
