### PR TITLE
refactor: expose storage backends metric names for doc generation

### DIFF
--- a/storage/azure/src/main/java/io/aiven/kafka/tieredstorage/storage/azure/MetricRegistry.java
+++ b/storage/azure/src/main/java/io/aiven/kafka/tieredstorage/storage/azure/MetricRegistry.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.azure;
+
+import java.util.List;
+
+import org.apache.kafka.common.MetricNameTemplate;
+
+public class MetricRegistry {
+    public static final String METRIC_CONTEXT = "aiven.kafka.server.tieredstorage.azure";
+
+    static final String METRIC_GROUP = "azure-blob-storage-client-metrics";
+    static final String BLOB_DELETE = "blob-delete";
+    static final String BLOB_DELETE_DOC = "object delete operations";
+    static final String BLOB_DELETE_RATE = BLOB_DELETE + "-rate";
+    static final String BLOB_DELETE_TOTAL = BLOB_DELETE + "-total";
+    static final String BLOB_UPLOAD = "blob-upload";
+    static final String BLOB_UPLOAD_DOC = "object upload operations";
+    static final String BLOB_UPLOAD_RATE = BLOB_UPLOAD + "-rate";
+    static final String BLOB_UPLOAD_TOTAL = BLOB_UPLOAD + "-total";
+    static final String BLOCK_UPLOAD = "block-upload";
+    static final String BLOCK_UPLOAD_RATE = BLOCK_UPLOAD + "-rate";
+    static final String BLOCK_UPLOAD_TOTAL = BLOCK_UPLOAD + "-total";
+    static final String BLOCK_UPLOAD_DOC = "block (blob part) upload operations";
+    static final String BLOCK_LIST_UPLOAD = "block-list-upload";
+    static final String BLOCK_LIST_UPLOAD_RATE = BLOCK_LIST_UPLOAD + "-rate";
+    static final String BLOCK_LIST_UPLOAD_TOTAL = BLOCK_LIST_UPLOAD + "-total";
+    static final String BLOCK_LIST_UPLOAD_DOC = "block list (making a blob) upload operations";
+    static final String BLOB_GET = "blob-get";
+    static final String BLOB_GET_RATE = BLOB_GET + "-rate";
+    static final String BLOB_GET_TOTAL = BLOB_GET + "-total";
+    static final String BLOB_GET_DOC = "get object operations";
+
+    private static final String RATE_DOC_PREFIX = "Rate of ";
+    private static final String TOTAL_DOC_PREFIX = "Total number of ";
+
+    static final MetricNameTemplate BLOB_DELETE_RATE_METRIC_NAME = new MetricNameTemplate(
+        BLOB_DELETE_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + BLOB_DELETE_DOC
+    );
+    static final MetricNameTemplate BLOB_DELETE_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        BLOB_DELETE_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + BLOB_DELETE_DOC
+    );
+    static final MetricNameTemplate BLOB_UPLOAD_RATE_METRIC_NAME = new MetricNameTemplate(
+        BLOB_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + BLOB_UPLOAD_DOC
+    );
+    static final MetricNameTemplate BLOB_UPLOAD_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        BLOB_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + BLOB_UPLOAD_DOC
+    );
+    static final MetricNameTemplate BLOCK_UPLOAD_RATE_METRIC_NAME = new MetricNameTemplate(
+        BLOCK_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + BLOCK_UPLOAD_DOC
+    );
+    static final MetricNameTemplate BLOCK_UPLOAD_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        BLOCK_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + BLOCK_UPLOAD_DOC
+    );
+    static final MetricNameTemplate BLOCK_LIST_UPLOAD_RATE_METRIC_NAME = new MetricNameTemplate(
+        BLOCK_LIST_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + BLOCK_LIST_UPLOAD_DOC
+    );
+    static final MetricNameTemplate BLOCK_LIST_UPLOAD_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        BLOCK_LIST_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + BLOCK_LIST_UPLOAD_DOC
+    );
+    static final MetricNameTemplate BLOB_GET_RATE_METRIC_NAME = new MetricNameTemplate(
+        BLOB_GET_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + BLOB_GET_DOC
+    );
+    static final MetricNameTemplate BLOB_GET_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        BLOB_GET_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + BLOB_GET_DOC
+    );
+
+    public List<MetricNameTemplate> all() {
+        return List.of(
+            BLOB_DELETE_RATE_METRIC_NAME,
+            BLOB_DELETE_TOTAL_METRIC_NAME,
+            BLOB_UPLOAD_RATE_METRIC_NAME,
+            BLOB_UPLOAD_TOTAL_METRIC_NAME,
+            BLOCK_UPLOAD_RATE_METRIC_NAME,
+            BLOCK_UPLOAD_TOTAL_METRIC_NAME,
+            BLOCK_LIST_UPLOAD_RATE_METRIC_NAME,
+            BLOCK_LIST_UPLOAD_TOTAL_METRIC_NAME,
+            BLOB_GET_RATE_METRIC_NAME,
+            BLOB_GET_TOTAL_METRIC_NAME
+        );
+    }
+}

--- a/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/MetricCollector.java
+++ b/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/MetricCollector.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -37,7 +38,24 @@ import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.http.HttpTransportOptions;
 
-class MetricCollector {
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.METRIC_CONTEXT;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_DELETE;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_DELETE_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_DELETE_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_GET;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_GET_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_GET_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_METADATA_GET;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_METADATA_GET_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.OBJECT_METADATA_GET_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.RESUMABLE_UPLOAD_INITIATE;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.gcs.MetricRegistry.RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME;
+
+public class MetricCollector {
     private final org.apache.kafka.common.metrics.Metrics metrics;
 
     /**
@@ -64,33 +82,55 @@ class MetricCollector {
     static final Pattern OBJECT_UPLOAD_PATH_PATTERN =
         Pattern.compile("^/upload/storage/v1/b/([^/]+)/o/?$");
 
-    private static final String METRIC_GROUP = "gcs-client-metrics";
-
     private final Sensor getObjectMetadataRequests;
     private final Sensor deleteObjectRequests;
     private final Sensor resumableUploadInitiateRequests;
     private final Sensor resumableChunkUploadRequests;
     private final Sensor getObjectRequests;
 
-    MetricCollector() {
+    public MetricCollector() {
         final JmxReporter reporter = new JmxReporter();
 
         metrics = new org.apache.kafka.common.metrics.Metrics(
             new MetricConfig(), List.of(reporter), Time.SYSTEM,
-            new KafkaMetricsContext("aiven.kafka.server.tieredstorage.gcs")
+            new KafkaMetricsContext(METRIC_CONTEXT)
         );
 
-        getObjectMetadataRequests = createSensor("object-metadata-get");
-        getObjectRequests = createSensor("object-get");
-        deleteObjectRequests = createSensor("object-delete");
-        resumableUploadInitiateRequests = createSensor("resumable-upload-initiate");
-        resumableChunkUploadRequests = createSensor("resumable-chunk-upload");
+        getObjectMetadataRequests = createSensor(
+            OBJECT_METADATA_GET,
+            OBJECT_METADATA_GET_RATE_METRIC_NAME,
+            OBJECT_METADATA_GET_TOTAL_METRIC_NAME
+        );
+        getObjectRequests = createSensor(
+            OBJECT_GET,
+            OBJECT_GET_RATE_METRIC_NAME,
+            OBJECT_GET_TOTAL_METRIC_NAME
+        );
+        deleteObjectRequests = createSensor(
+            OBJECT_DELETE,
+            OBJECT_DELETE_RATE_METRIC_NAME,
+            OBJECT_DELETE_TOTAL_METRIC_NAME
+        );
+        resumableUploadInitiateRequests = createSensor(
+            RESUMABLE_UPLOAD_INITIATE,
+            RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME,
+            RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME
+        );
+        resumableChunkUploadRequests = createSensor(
+            RESUMABLE_CHUNK_UPLOAD,
+            RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME,
+            RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME
+        );
     }
 
-    private Sensor createSensor(final String name) {
+    private Sensor createSensor(
+        final String name,
+        final MetricNameTemplate rateMetricName,
+        final MetricNameTemplate totalMetricName
+    ) {
         final Sensor sensor = metrics.sensor(name);
-        sensor.add(metrics.metricName(name + "-rate", METRIC_GROUP), new Rate());
-        sensor.add(metrics.metricName(name + "-total", METRIC_GROUP), new CumulativeCount());
+        sensor.add(metrics.metricInstance(rateMetricName), new Rate());
+        sensor.add(metrics.metricInstance(totalMetricName), new CumulativeCount());
         return sensor;
     }
 

--- a/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/MetricRegistry.java
+++ b/storage/gcs/src/main/java/io/aiven/kafka/tieredstorage/storage/gcs/MetricRegistry.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.gcs;
+
+import java.util.List;
+
+import org.apache.kafka.common.MetricNameTemplate;
+
+public class MetricRegistry {
+    public static final String METRIC_CONTEXT = "aiven.kafka.server.tieredstorage.gcs";
+
+    static final String METRIC_GROUP = "gcs-client-metrics";
+    static final String OBJECT_METADATA_GET = "object-metadata-get";
+    static final String OBJECT_METADATA_GET_RATE = OBJECT_METADATA_GET + "-rate";
+    static final String OBJECT_METADATA_GET_TOTAL = OBJECT_METADATA_GET + "-total";
+    static final String OBJECT_METADATA_GET_DOC = "get object metadata operations";
+    static final String OBJECT_GET = "object-get";
+    static final String OBJECT_GET_RATE = OBJECT_GET + "-rate";
+    static final String OBJECT_GET_TOTAL = OBJECT_GET + "-total";
+    static final String OBJECT_GET_DOC = "get object operations";
+    static final String OBJECT_DELETE = "object-delete";
+    static final String OBJECT_DELETE_RATE = OBJECT_DELETE + "-rate";
+    static final String OBJECT_DELETE_TOTAL = OBJECT_DELETE + "-total";
+    static final String OBJECT_DELETE_DOC = "delete object operations";
+    static final String RESUMABLE_UPLOAD_INITIATE = "resumable-upload-initiate";
+    static final String RESUMABLE_UPLOAD_INITIATE_RATE = RESUMABLE_UPLOAD_INITIATE + "-rate";
+    static final String RESUMABLE_UPLOAD_INITIATE_TOTAL = RESUMABLE_UPLOAD_INITIATE + "-total";
+    static final String RESUMABLE_UPLOAD_INITIATE_DOC = "initiate resumable upload operations";
+    static final String RESUMABLE_CHUNK_UPLOAD = "resumable-chunk-upload";
+    static final String RESUMABLE_CHUNK_UPLOAD_RATE = RESUMABLE_CHUNK_UPLOAD + "-rate";
+    static final String RESUMABLE_CHUNK_UPLOAD_TOTAL = RESUMABLE_CHUNK_UPLOAD + "-total";
+    static final String RESUMABLE_CHUNK_UPLOAD_DOC = "upload chunk operations as part of resumable upload";
+
+    private static final String RATE_DOC_PREFIX = "Rate of ";
+    private static final String TOTAL_DOC_PREFIX = "Total number of ";
+
+    static final MetricNameTemplate OBJECT_METADATA_GET_RATE_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_METADATA_GET_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_METADATA_GET_DOC
+    );
+    static final MetricNameTemplate OBJECT_METADATA_GET_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_METADATA_GET_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_METADATA_GET_DOC
+    );
+    static final MetricNameTemplate OBJECT_GET_RATE_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_GET_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_GET_DOC
+    );
+    static final MetricNameTemplate OBJECT_GET_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_GET_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_GET_DOC
+    );
+    static final MetricNameTemplate OBJECT_DELETE_RATE_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_DELETE_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OBJECT_DELETE_DOC
+    );
+    static final MetricNameTemplate OBJECT_DELETE_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        OBJECT_DELETE_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OBJECT_DELETE_DOC
+    );
+    static final MetricNameTemplate RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME = new MetricNameTemplate(
+        RESUMABLE_UPLOAD_INITIATE_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + RESUMABLE_UPLOAD_INITIATE_DOC
+    );
+    static final MetricNameTemplate RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        RESUMABLE_UPLOAD_INITIATE_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + RESUMABLE_UPLOAD_INITIATE_DOC
+    );
+    static final MetricNameTemplate RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME = new MetricNameTemplate(
+        RESUMABLE_CHUNK_UPLOAD_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + RESUMABLE_CHUNK_UPLOAD_DOC
+    );
+    static final MetricNameTemplate RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        RESUMABLE_CHUNK_UPLOAD_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + RESUMABLE_CHUNK_UPLOAD_DOC
+    );
+
+    public List<MetricNameTemplate> all() {
+        return List.of(
+            OBJECT_METADATA_GET_RATE_METRIC_NAME,
+            OBJECT_METADATA_GET_TOTAL_METRIC_NAME,
+            OBJECT_GET_RATE_METRIC_NAME,
+            OBJECT_GET_TOTAL_METRIC_NAME,
+            OBJECT_DELETE_RATE_METRIC_NAME,
+            OBJECT_DELETE_TOTAL_METRIC_NAME,
+            RESUMABLE_UPLOAD_INITIATE_RATE_METRIC_NAME,
+            RESUMABLE_UPLOAD_INITIATE_TOTAL_METRIC_NAME,
+            RESUMABLE_CHUNK_UPLOAD_RATE_METRIC_NAME,
+            RESUMABLE_CHUNK_UPLOAD_TOTAL_METRIC_NAME
+        );
+    }
+}

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -39,64 +40,240 @@ import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.metrics.MetricCollection;
 import software.amazon.awssdk.metrics.MetricPublisher;
 
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.ABORT_MULTIPART_UPLOAD_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.ABORT_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.ABORT_MULTIPART_UPLOAD_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.ABORT_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.ABORT_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.COMPLETE_MULTIPART_UPLOAD_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.COMPLETE_MULTIPART_UPLOAD_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.COMPLETE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.COMPLETE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CONFIGURED_TIMEOUT_ERRORS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CONFIGURED_TIMEOUT_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CONFIGURED_TIMEOUT_ERRORS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CREATE_MULTIPART_UPLOAD_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CREATE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CREATE_MULTIPART_UPLOAD_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CREATE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.CREATE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECTS_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECTS_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECTS_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECTS_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECTS_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECTS_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECT_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECT_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECT_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECT_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECT_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.DELETE_OBJECT_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.GET_OBJECT_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.GET_OBJECT_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.GET_OBJECT_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.GET_OBJECT_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.GET_OBJECT_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.GET_OBJECT_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.IO_ERRORS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.IO_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.IO_ERRORS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.METRIC_CONTEXT;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.OTHER_ERRORS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.OTHER_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.OTHER_ERRORS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.PUT_OBJECT_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.PUT_OBJECT_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.PUT_OBJECT_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.PUT_OBJECT_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.PUT_OBJECT_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.PUT_OBJECT_TIME_MAX_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.SERVER_ERRORS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.SERVER_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.SERVER_ERRORS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.THROTTLING_ERRORS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.THROTTLING_ERRORS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.THROTTLING_ERRORS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.UPLOAD_PART_REQUESTS;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.UPLOAD_PART_REQUESTS_RATE_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.UPLOAD_PART_REQUESTS_TOTAL_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.UPLOAD_PART_TIME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.UPLOAD_PART_TIME_AVG_METRIC_NAME;
+import static io.aiven.kafka.tieredstorage.storage.s3.MetricRegistry.UPLOAD_PART_TIME_MAX_METRIC_NAME;
 import static software.amazon.awssdk.core.internal.metrics.SdkErrorType.CONFIGURED_TIMEOUT;
 import static software.amazon.awssdk.core.internal.metrics.SdkErrorType.IO;
 import static software.amazon.awssdk.core.internal.metrics.SdkErrorType.OTHER;
 import static software.amazon.awssdk.core.internal.metrics.SdkErrorType.SERVER_ERROR;
 import static software.amazon.awssdk.core.internal.metrics.SdkErrorType.THROTTLING;
 
-class MetricCollector implements MetricPublisher {
+public class MetricCollector implements MetricPublisher {
     private static final Logger log = LoggerFactory.getLogger(MetricCollector.class);
 
     private final org.apache.kafka.common.metrics.Metrics metrics;
 
-    private static final String METRIC_GROUP = "s3-client-metrics";
     private final Map<String, Sensor> requestMetrics = new HashMap<>();
     private final Map<String, Sensor> latencyMetrics = new HashMap<>();
     private final Map<String, Sensor> errorMetrics = new HashMap<>();
 
-    MetricCollector() {
+    public MetricCollector() {
         final MetricsReporter reporter = new JmxReporter();
 
         metrics = new org.apache.kafka.common.metrics.Metrics(
             new MetricConfig(), List.of(reporter), Time.SYSTEM,
-            new KafkaMetricsContext("aiven.kafka.server.tieredstorage.s3")
+            new KafkaMetricsContext(METRIC_CONTEXT)
         );
-        requestMetrics.put("GetObject", createRequestsSensor("get-object-requests"));
-        latencyMetrics.put("GetObject", createLatencySensor("get-object-time"));
-        requestMetrics.put("UploadPart", createRequestsSensor("upload-part-requests"));
-        latencyMetrics.put("UploadPart", createLatencySensor("upload-part-time"));
-        requestMetrics.put("CreateMultipartUpload", createRequestsSensor("create-multipart-upload-requests"));
-        latencyMetrics.put("CreateMultipartUpload", createLatencySensor("create-multipart-upload-time"));
-        requestMetrics.put("CompleteMultipartUpload", createRequestsSensor("complete-multipart-upload-requests"));
-        latencyMetrics.put("CompleteMultipartUpload", createLatencySensor("complete-multipart-upload-time"));
-        requestMetrics.put("PutObject", createRequestsSensor("put-object-requests"));
-        latencyMetrics.put("PutObject", createLatencySensor("put-object-time"));
-        requestMetrics.put("DeleteObject", createRequestsSensor("delete-object-requests"));
-        latencyMetrics.put("DeleteObject", createLatencySensor("delete-object-time"));
-        requestMetrics.put("DeleteObjects", createRequestsSensor("delete-objects-requests"));
-        latencyMetrics.put("DeleteObjects", createLatencySensor("delete-objects-time"));
-        requestMetrics.put("AbortMultipartUpload", createRequestsSensor("abort-multipart-upload-requests"));
-        latencyMetrics.put("AbortMultipartUpload", createLatencySensor("abort-multipart-upload-time"));
+        final Sensor getObjectRequestsSensor = createRequestsSensor(
+            GET_OBJECT_REQUESTS,
+            GET_OBJECT_REQUESTS_RATE_METRIC_NAME,
+            GET_OBJECT_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("GetObject", getObjectRequestsSensor);
+        final Sensor getObjectTimeSensor = createLatencySensor(
+            GET_OBJECT_TIME,
+            GET_OBJECT_TIME_AVG_METRIC_NAME,
+            GET_OBJECT_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("GetObject", getObjectTimeSensor);
+        final Sensor uploadPartRequestsSensor = createRequestsSensor(
+            UPLOAD_PART_REQUESTS,
+            UPLOAD_PART_REQUESTS_RATE_METRIC_NAME,
+            UPLOAD_PART_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("UploadPart", uploadPartRequestsSensor);
+        final Sensor uploadPartTimeSensor = createLatencySensor(
+            UPLOAD_PART_TIME,
+            UPLOAD_PART_TIME_AVG_METRIC_NAME,
+            UPLOAD_PART_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("UploadPart", uploadPartTimeSensor);
+        final Sensor createMpuRequestsSensor = createRequestsSensor(
+            CREATE_MULTIPART_UPLOAD_REQUESTS,
+            CREATE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
+            CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("CreateMultipartUpload", createMpuRequestsSensor);
+        final Sensor createMpuTimeSensor = createLatencySensor(
+            CREATE_MULTIPART_UPLOAD_TIME,
+            CREATE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
+            CREATE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("CreateMultipartUpload", createMpuTimeSensor);
+        final Sensor completeMpuRequestsSensor = createRequestsSensor(
+            COMPLETE_MULTIPART_UPLOAD_REQUESTS,
+            COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
+            COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("CompleteMultipartUpload", completeMpuRequestsSensor);
+        final Sensor completeMpuTimeSensor = createLatencySensor(
+            COMPLETE_MULTIPART_UPLOAD_TIME,
+            COMPLETE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
+            COMPLETE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("CompleteMultipartUpload", completeMpuTimeSensor);
+        final Sensor putObjectRequestsSensor = createRequestsSensor(
+            PUT_OBJECT_REQUESTS,
+            PUT_OBJECT_REQUESTS_RATE_METRIC_NAME,
+            PUT_OBJECT_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("PutObject", putObjectRequestsSensor);
+        final Sensor putObjectTimeSensor = createLatencySensor(
+            PUT_OBJECT_TIME,
+            PUT_OBJECT_TIME_AVG_METRIC_NAME,
+            PUT_OBJECT_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("PutObject", putObjectTimeSensor);
+        final Sensor deleteObjectRequestsSensor = createRequestsSensor(
+            DELETE_OBJECT_REQUESTS,
+            DELETE_OBJECT_REQUESTS_RATE_METRIC_NAME,
+            DELETE_OBJECT_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("DeleteObject", deleteObjectRequestsSensor);
+        final Sensor deleteObjectTimeSensor = createLatencySensor(
+            DELETE_OBJECT_TIME,
+            DELETE_OBJECT_TIME_AVG_METRIC_NAME,
+            DELETE_OBJECT_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("DeleteObject", deleteObjectTimeSensor);
+        final Sensor deleteObjectsRequestsSensor = createRequestsSensor(
+            DELETE_OBJECTS_REQUESTS,
+            DELETE_OBJECTS_REQUESTS_RATE_METRIC_NAME,
+            DELETE_OBJECTS_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("DeleteObjects", deleteObjectsRequestsSensor);
+        final Sensor deleteObjectsTimeSensor = createLatencySensor(
+            DELETE_OBJECTS_TIME,
+            DELETE_OBJECTS_TIME_AVG_METRIC_NAME,
+            DELETE_OBJECTS_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("DeleteObjects", deleteObjectsTimeSensor);
+        final Sensor abortMpuRequestsSensor = createRequestsSensor(
+            ABORT_MULTIPART_UPLOAD_REQUESTS,
+            ABORT_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
+            ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
+        );
+        requestMetrics.put("AbortMultipartUpload", abortMpuRequestsSensor);
+        final Sensor abortMpuTimeSensor = createLatencySensor(
+            ABORT_MULTIPART_UPLOAD_TIME,
+            ABORT_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
+            ABORT_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
+        );
+        latencyMetrics.put("AbortMultipartUpload", abortMpuTimeSensor);
 
-        errorMetrics.put(THROTTLING.toString(), createRequestsSensor("throttling-errors"));
-        errorMetrics.put(SERVER_ERROR.toString(), createRequestsSensor("server-errors"));
-        errorMetrics.put(CONFIGURED_TIMEOUT.toString(), createRequestsSensor("configured-timeout-errors"));
-        errorMetrics.put(IO.toString(), createRequestsSensor("io-errors"));
-        errorMetrics.put(OTHER.toString(), createRequestsSensor("other-errors"));
+        final Sensor throttlingErrorsSensor = createRequestsSensor(
+            THROTTLING_ERRORS,
+            THROTTLING_ERRORS_RATE_METRIC_NAME,
+            THROTTLING_ERRORS_TOTAL_METRIC_NAME
+        );
+        errorMetrics.put(THROTTLING.toString(), throttlingErrorsSensor);
+        final Sensor serverErrorsSensor = createRequestsSensor(
+            SERVER_ERRORS,
+            SERVER_ERRORS_RATE_METRIC_NAME,
+            SERVER_ERRORS_TOTAL_METRIC_NAME
+        );
+        errorMetrics.put(SERVER_ERROR.toString(), serverErrorsSensor);
+        final Sensor configuredTimeoutErrorsSensor = createRequestsSensor(
+            CONFIGURED_TIMEOUT_ERRORS,
+            CONFIGURED_TIMEOUT_ERRORS_RATE_METRIC_NAME,
+            CONFIGURED_TIMEOUT_ERRORS_TOTAL_METRIC_NAME
+        );
+        errorMetrics.put(CONFIGURED_TIMEOUT.toString(), configuredTimeoutErrorsSensor);
+        final Sensor ioErrorsSensor = createRequestsSensor(
+            IO_ERRORS,
+            IO_ERRORS_RATE_METRIC_NAME,
+            IO_ERRORS_TOTAL_METRIC_NAME
+        );
+        errorMetrics.put(IO.toString(), ioErrorsSensor);
+        final Sensor otherErrorsSensor = createRequestsSensor(
+            OTHER_ERRORS,
+            OTHER_ERRORS_RATE_METRIC_NAME,
+            OTHER_ERRORS_TOTAL_METRIC_NAME
+        );
+        errorMetrics.put(OTHER.toString(), otherErrorsSensor);
     }
 
-    private Sensor createRequestsSensor(final String name) {
+    private Sensor createRequestsSensor(
+        final String name,
+        final MetricNameTemplate rateMetricName,
+        final MetricNameTemplate totalMetricName
+    ) {
         final Sensor sensor = metrics.sensor(name);
-        sensor.add(metrics.metricName(name + "-rate", METRIC_GROUP), new Rate());
-        sensor.add(metrics.metricName(name + "-total", METRIC_GROUP), new CumulativeCount());
+        sensor.add(metrics.metricInstance(rateMetricName), new Rate());
+        sensor.add(metrics.metricInstance(totalMetricName), new CumulativeCount());
         return sensor;
     }
 
-    private Sensor createLatencySensor(final String name) {
+    private Sensor createLatencySensor(
+        final String name,
+        final MetricNameTemplate avgMetricName,
+        final MetricNameTemplate maxMetricName
+    ) {
         final Sensor sensor = metrics.sensor(name);
-        sensor.add(metrics.metricName(name + "-max", METRIC_GROUP), new Max());
-        sensor.add(metrics.metricName(name + "-avg", METRIC_GROUP), new Avg());
+        sensor.add(metrics.metricInstance(maxMetricName), new Max());
+        sensor.add(metrics.metricInstance(avgMetricName), new Avg());
         return sensor;
     }
 

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricRegistry.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricRegistry.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.s3;
+
+import java.util.List;
+
+import org.apache.kafka.common.MetricNameTemplate;
+
+public class MetricRegistry {
+    public static final String METRIC_CONTEXT = "aiven.kafka.server.tieredstorage.s3";
+
+    static final String METRIC_GROUP = "s3-client-metrics";
+    static final String GET_OBJECT_REQUESTS = "get-object-requests";
+    static final String GET_OBJECT_REQUESTS_RATE = GET_OBJECT_REQUESTS + "-rate";
+    static final String GET_OBJECT_REQUESTS_TOTAL = GET_OBJECT_REQUESTS + "-total";
+    static final String GET_OBJECT_REQUESTS_DOC = "get object request operations";
+    static final String GET_OBJECT_TIME = "get-object-time";
+    static final String GET_OBJECT_TIME_AVG = GET_OBJECT_TIME + "-avg";
+    static final String GET_OBJECT_TIME_MAX = GET_OBJECT_TIME + "-max";
+    static final String GET_OBJECT_TIME_DOC = "time spent getting a response from a get object request";
+    static final String PUT_OBJECT_REQUESTS = "put-object-requests";
+    static final String PUT_OBJECT_REQUESTS_RATE = PUT_OBJECT_REQUESTS + "-rate";
+    static final String PUT_OBJECT_REQUESTS_TOTAL = PUT_OBJECT_REQUESTS + "-total";
+    static final String PUT_OBJECT_REQUESTS_DOC = "put object request operations";
+    static final String PUT_OBJECT_TIME = "put-object-time";
+    static final String PUT_OBJECT_TIME_AVG = PUT_OBJECT_TIME + "-avg";
+    static final String PUT_OBJECT_TIME_MAX = PUT_OBJECT_TIME + "-max";
+    static final String PUT_OBJECT_TIME_DOC = "time spent uploading an object";
+    static final String DELETE_OBJECT_REQUESTS = "delete-object-requests";
+    static final String DELETE_OBJECT_REQUESTS_RATE = DELETE_OBJECT_REQUESTS + "-rate";
+    static final String DELETE_OBJECT_REQUESTS_TOTAL = DELETE_OBJECT_REQUESTS + "-total";
+    static final String DELETE_OBJECT_REQUESTS_DOC = "delete object request operations";
+    static final String DELETE_OBJECT_TIME = "delete-object-time";
+    static final String DELETE_OBJECT_TIME_AVG = DELETE_OBJECT_TIME + "-avg";
+    static final String DELETE_OBJECT_TIME_MAX = DELETE_OBJECT_TIME + "-max";
+    static final String DELETE_OBJECT_TIME_DOC = "time spent deleting an object";
+    static final String DELETE_OBJECTS_REQUESTS = "delete-objects-requests";
+    static final String DELETE_OBJECTS_REQUESTS_RATE = DELETE_OBJECTS_REQUESTS + "-rate";
+    static final String DELETE_OBJECTS_REQUESTS_TOTAL = DELETE_OBJECTS_REQUESTS + "-total";
+    static final String DELETE_OBJECTS_REQUESTS_DOC = "delete a set of objects request operations";
+    static final String DELETE_OBJECTS_TIME = "delete-objects-time";
+    static final String DELETE_OBJECTS_TIME_AVG = DELETE_OBJECTS_TIME + "-avg";
+    static final String DELETE_OBJECTS_TIME_MAX = DELETE_OBJECTS_TIME + "-max";
+    static final String DELETE_OBJECTS_TIME_DOC = "time spent deleting a set of objects";
+    static final String UPLOAD_PART_REQUESTS = "upload-part-requests";
+    static final String UPLOAD_PART_REQUESTS_RATE = UPLOAD_PART_REQUESTS + "-rate";
+    static final String UPLOAD_PART_REQUESTS_TOTAL = UPLOAD_PART_REQUESTS + "-total";
+    static final String UPLOAD_PART_REQUESTS_DOC = "upload part request operations "
+        + "(as part of multi-part upload)";
+    static final String UPLOAD_PART_TIME = "upload-part-time";
+    static final String UPLOAD_PART_TIME_AVG = UPLOAD_PART_TIME + "-avg";
+    static final String UPLOAD_PART_TIME_MAX = UPLOAD_PART_TIME + "-max";
+    static final String UPLOAD_PART_TIME_DOC = "time spent uploading a single part";
+    static final String CREATE_MULTIPART_UPLOAD_REQUESTS = "create-multipart-upload-requests";
+    static final String CREATE_MULTIPART_UPLOAD_REQUESTS_RATE = CREATE_MULTIPART_UPLOAD_REQUESTS + "-rate";
+    static final String CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL = CREATE_MULTIPART_UPLOAD_REQUESTS + "-total";
+    static final String CREATE_MULTIPART_UPLOAD_REQUESTS_DOC = "create multi-part upload operations";
+    static final String CREATE_MULTIPART_UPLOAD_TIME = "create-multipart-upload-time";
+    static final String CREATE_MULTIPART_UPLOAD_TIME_AVG = CREATE_MULTIPART_UPLOAD_TIME + "-avg";
+    static final String CREATE_MULTIPART_UPLOAD_TIME_MAX = CREATE_MULTIPART_UPLOAD_TIME + "-max";
+    static final String CREATE_MULTIPART_UPLOAD_TIME_DOC = "time spent creating a new multi-part upload operation";
+    static final String COMPLETE_MULTIPART_UPLOAD_REQUESTS = "complete-multipart-upload-requests";
+    static final String COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE = COMPLETE_MULTIPART_UPLOAD_REQUESTS + "-rate";
+    static final String COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL = COMPLETE_MULTIPART_UPLOAD_REQUESTS + "-total";
+    static final String COMPLETE_MULTIPART_UPLOAD_REQUESTS_DOC = "complete multi-part upload operations";
+    static final String COMPLETE_MULTIPART_UPLOAD_TIME = "complete-multipart-upload-time";
+    static final String COMPLETE_MULTIPART_UPLOAD_TIME_AVG = COMPLETE_MULTIPART_UPLOAD_TIME + "-avg";
+    static final String COMPLETE_MULTIPART_UPLOAD_TIME_MAX = COMPLETE_MULTIPART_UPLOAD_TIME + "-max";
+    static final String COMPLETE_MULTIPART_UPLOAD_TIME_DOC = "time spent completing a new multi-part upload operation";
+    static final String ABORT_MULTIPART_UPLOAD_REQUESTS = "abort-multipart-upload-requests";
+    static final String ABORT_MULTIPART_UPLOAD_REQUESTS_RATE = ABORT_MULTIPART_UPLOAD_REQUESTS + "-rate";
+    static final String ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL = ABORT_MULTIPART_UPLOAD_REQUESTS + "-total";
+    static final String ABORT_MULTIPART_UPLOAD_REQUESTS_DOC = "abort multi-part upload operations";
+    static final String ABORT_MULTIPART_UPLOAD_TIME = "abort-multipart-upload-time";
+    static final String ABORT_MULTIPART_UPLOAD_TIME_AVG = ABORT_MULTIPART_UPLOAD_TIME + "-avg";
+    static final String ABORT_MULTIPART_UPLOAD_TIME_MAX = ABORT_MULTIPART_UPLOAD_TIME + "-max";
+    static final String ABORT_MULTIPART_UPLOAD_TIME_DOC = "time spent aborting a new multi-part upload operation";
+
+    static final String THROTTLING_ERRORS = "throttling-errors";
+    static final String THROTTLING_ERRORS_RATE = THROTTLING_ERRORS + "-rate";
+    static final String THROTTLING_ERRORS_TOTAL = THROTTLING_ERRORS + "-total";
+    static final String THROTTLING_ERRORS_DOC = "throttling errors";
+    static final String SERVER_ERRORS = "server-errors";
+    static final String SERVER_ERRORS_RATE = SERVER_ERRORS + "-rate";
+    static final String SERVER_ERRORS_TOTAL = SERVER_ERRORS + "-total";
+    static final String SERVER_ERRORS_DOC = "server errors";
+    static final String CONFIGURED_TIMEOUT_ERRORS = "configured-timeout-errors";
+    static final String CONFIGURED_TIMEOUT_ERRORS_RATE = CONFIGURED_TIMEOUT_ERRORS + "-rate";
+    static final String CONFIGURED_TIMEOUT_ERRORS_TOTAL = CONFIGURED_TIMEOUT_ERRORS + "-total";
+    static final String CONFIGURED_TIMEOUT_ERRORS_DOC = "configured timeout errors";
+    static final String IO_ERRORS = "io-errors";
+    static final String IO_ERRORS_RATE = IO_ERRORS + "-rate";
+    static final String IO_ERRORS_TOTAL = IO_ERRORS + "-total";
+    static final String IO_ERRORS_DOC = "IO errors";
+    static final String OTHER_ERRORS = "other-errors";
+    static final String OTHER_ERRORS_RATE = OTHER_ERRORS + "-rate";
+    static final String OTHER_ERRORS_TOTAL = OTHER_ERRORS + "-total";
+    static final String OTHER_ERRORS_DOC = "other errors";
+
+    private static final String RATE_DOC_PREFIX = "Rate of ";
+    private static final String TOTAL_DOC_PREFIX = "Total number of ";
+    private static final String AVG_DOC_PREFIX = "Average ";
+    private static final String MAX_DOC_PREFIX = "Maximum ";
+
+    static final MetricNameTemplate GET_OBJECT_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        GET_OBJECT_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + GET_OBJECT_REQUESTS_DOC
+    );
+    static final MetricNameTemplate GET_OBJECT_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        GET_OBJECT_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + GET_OBJECT_REQUESTS_DOC
+    );
+    static final MetricNameTemplate GET_OBJECT_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        GET_OBJECT_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + GET_OBJECT_TIME_DOC
+    );
+    static final MetricNameTemplate GET_OBJECT_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        GET_OBJECT_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + GET_OBJECT_TIME_DOC
+    );
+    static final MetricNameTemplate PUT_OBJECT_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        PUT_OBJECT_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + PUT_OBJECT_REQUESTS_DOC
+    );
+    static final MetricNameTemplate PUT_OBJECT_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        PUT_OBJECT_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + PUT_OBJECT_REQUESTS_DOC
+    );
+    static final MetricNameTemplate PUT_OBJECT_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        PUT_OBJECT_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + PUT_OBJECT_TIME_DOC
+    );
+    static final MetricNameTemplate PUT_OBJECT_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        PUT_OBJECT_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + PUT_OBJECT_TIME_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECT_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECT_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + DELETE_OBJECT_REQUESTS_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECT_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECT_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + DELETE_OBJECT_REQUESTS_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECT_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECT_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + DELETE_OBJECT_TIME_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECT_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECT_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + DELETE_OBJECT_TIME_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECTS_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECTS_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + DELETE_OBJECTS_REQUESTS_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECTS_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECTS_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + DELETE_OBJECTS_REQUESTS_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECTS_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECTS_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + DELETE_OBJECTS_TIME_DOC
+    );
+    static final MetricNameTemplate DELETE_OBJECTS_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        DELETE_OBJECTS_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + DELETE_OBJECTS_TIME_DOC
+    );
+    static final MetricNameTemplate UPLOAD_PART_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        UPLOAD_PART_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + UPLOAD_PART_REQUESTS_DOC
+    );
+    static final MetricNameTemplate UPLOAD_PART_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        UPLOAD_PART_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + UPLOAD_PART_REQUESTS_DOC
+    );
+    static final MetricNameTemplate UPLOAD_PART_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        UPLOAD_PART_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + UPLOAD_PART_TIME_DOC
+    );
+    static final MetricNameTemplate UPLOAD_PART_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        UPLOAD_PART_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + UPLOAD_PART_TIME_DOC
+    );
+    static final MetricNameTemplate CREATE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        CREATE_MULTIPART_UPLOAD_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + CREATE_MULTIPART_UPLOAD_REQUESTS_DOC
+    );
+    static final MetricNameTemplate CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + CREATE_MULTIPART_UPLOAD_REQUESTS_DOC
+    );
+    static final MetricNameTemplate CREATE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        CREATE_MULTIPART_UPLOAD_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + CREATE_MULTIPART_UPLOAD_TIME_DOC
+    );
+    static final MetricNameTemplate CREATE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        CREATE_MULTIPART_UPLOAD_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + CREATE_MULTIPART_UPLOAD_TIME_DOC
+    );
+    static final MetricNameTemplate COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + COMPLETE_MULTIPART_UPLOAD_REQUESTS_DOC
+    );
+    static final MetricNameTemplate COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + COMPLETE_MULTIPART_UPLOAD_REQUESTS_DOC
+    );
+    static final MetricNameTemplate COMPLETE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        COMPLETE_MULTIPART_UPLOAD_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + COMPLETE_MULTIPART_UPLOAD_TIME_DOC
+    );
+    static final MetricNameTemplate COMPLETE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        COMPLETE_MULTIPART_UPLOAD_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + COMPLETE_MULTIPART_UPLOAD_TIME_DOC
+    );
+    static final MetricNameTemplate ABORT_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME = new MetricNameTemplate(
+        ABORT_MULTIPART_UPLOAD_REQUESTS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + ABORT_MULTIPART_UPLOAD_REQUESTS_DOC
+    );
+    static final MetricNameTemplate ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + ABORT_MULTIPART_UPLOAD_REQUESTS_DOC
+    );
+    static final MetricNameTemplate ABORT_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME = new MetricNameTemplate(
+        ABORT_MULTIPART_UPLOAD_TIME_AVG,
+        METRIC_GROUP,
+        AVG_DOC_PREFIX + ABORT_MULTIPART_UPLOAD_TIME_DOC
+    );
+    static final MetricNameTemplate ABORT_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME = new MetricNameTemplate(
+        ABORT_MULTIPART_UPLOAD_TIME_MAX,
+        METRIC_GROUP,
+        MAX_DOC_PREFIX + ABORT_MULTIPART_UPLOAD_TIME_DOC
+    );
+
+    static final MetricNameTemplate THROTTLING_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        THROTTLING_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + THROTTLING_ERRORS_DOC
+    );
+    static final MetricNameTemplate THROTTLING_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        THROTTLING_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + THROTTLING_ERRORS_DOC
+    );
+    static final MetricNameTemplate SERVER_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        SERVER_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + SERVER_ERRORS_DOC
+    );
+    static final MetricNameTemplate SERVER_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        SERVER_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + SERVER_ERRORS_DOC
+    );
+    static final MetricNameTemplate CONFIGURED_TIMEOUT_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        CONFIGURED_TIMEOUT_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + CONFIGURED_TIMEOUT_ERRORS_DOC
+    );
+    static final MetricNameTemplate CONFIGURED_TIMEOUT_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        CONFIGURED_TIMEOUT_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + CONFIGURED_TIMEOUT_ERRORS_DOC
+    );
+    static final MetricNameTemplate IO_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        IO_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + IO_ERRORS_DOC
+    );
+    static final MetricNameTemplate IO_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        IO_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + IO_ERRORS_DOC
+    );
+    static final MetricNameTemplate OTHER_ERRORS_RATE_METRIC_NAME = new MetricNameTemplate(
+        OTHER_ERRORS_RATE,
+        METRIC_GROUP,
+        RATE_DOC_PREFIX + OTHER_ERRORS_DOC
+    );
+    static final MetricNameTemplate OTHER_ERRORS_TOTAL_METRIC_NAME = new MetricNameTemplate(
+        OTHER_ERRORS_TOTAL,
+        METRIC_GROUP,
+        TOTAL_DOC_PREFIX + OTHER_ERRORS_DOC
+    );
+
+    public List<MetricNameTemplate> all() {
+        return List.of(
+            GET_OBJECT_REQUESTS_RATE_METRIC_NAME,
+            GET_OBJECT_REQUESTS_TOTAL_METRIC_NAME,
+            GET_OBJECT_TIME_AVG_METRIC_NAME,
+            GET_OBJECT_TIME_MAX_METRIC_NAME,
+            PUT_OBJECT_REQUESTS_RATE_METRIC_NAME,
+            PUT_OBJECT_REQUESTS_TOTAL_METRIC_NAME,
+            PUT_OBJECT_TIME_AVG_METRIC_NAME,
+            PUT_OBJECT_TIME_MAX_METRIC_NAME,
+            DELETE_OBJECT_REQUESTS_RATE_METRIC_NAME,
+            DELETE_OBJECT_REQUESTS_TOTAL_METRIC_NAME,
+            DELETE_OBJECT_TIME_AVG_METRIC_NAME,
+            DELETE_OBJECT_TIME_MAX_METRIC_NAME,
+            DELETE_OBJECTS_REQUESTS_RATE_METRIC_NAME,
+            DELETE_OBJECTS_REQUESTS_TOTAL_METRIC_NAME,
+            DELETE_OBJECTS_TIME_AVG_METRIC_NAME,
+            DELETE_OBJECTS_TIME_MAX_METRIC_NAME,
+            UPLOAD_PART_REQUESTS_RATE_METRIC_NAME,
+            UPLOAD_PART_REQUESTS_TOTAL_METRIC_NAME,
+            UPLOAD_PART_TIME_AVG_METRIC_NAME,
+            UPLOAD_PART_TIME_MAX_METRIC_NAME,
+            CREATE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
+            CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME,
+            CREATE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
+            CREATE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME,
+            COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
+            COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME,
+            COMPLETE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
+            COMPLETE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME,
+            ABORT_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
+            ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME,
+            ABORT_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
+            ABORT_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME,
+            THROTTLING_ERRORS_RATE_METRIC_NAME,
+            THROTTLING_ERRORS_TOTAL_METRIC_NAME,
+            SERVER_ERRORS_RATE_METRIC_NAME,
+            SERVER_ERRORS_TOTAL_METRIC_NAME,
+            CONFIGURED_TIMEOUT_ERRORS_RATE_METRIC_NAME,
+            CONFIGURED_TIMEOUT_ERRORS_TOTAL_METRIC_NAME,
+            IO_ERRORS_RATE_METRIC_NAME,
+            IO_ERRORS_TOTAL_METRIC_NAME,
+            OTHER_ERRORS_RATE_METRIC_NAME,
+            OTHER_ERRORS_TOTAL_METRIC_NAME
+        );
+    }
+}


### PR DESCRIPTION
Add a metric registry for Azure, GCS, S3 metrics, document metrics, and expose metric name templates to be used on documentation generation.
