### PR TITLE
MINOR: Explicitly document how the minimum GCS resumable upload chunksize is set

### DIFF
--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -376,7 +376,7 @@ AzureBlobStorageStorageConfig
   * Importance: medium
 
 ``gcs.resumable.upload.chunk.size``
-  The chunk size for resumable upload. Must be a multiple of 256 KiB (256 x 1024 bytes). Larger chunk sizes typically make uploads faster, but requires bigger memory buffers. The recommended minimum is 8 MiB. The default is 15 MiB.
+  The chunk size for resumable upload. Must be a multiple of 256 KiB (256 x 1024 bytes). Larger chunk sizes typically make uploads faster, but requires bigger memory buffers. The recommended minimum is 8 MiB. The default is 15 MiB, `dictated by the GCS SDK <https://cloud.google.com/storage/docs/resumable-uploads#java>`_ when we set it to null.
 
   * Type: int
   * Default: null


### PR DESCRIPTION
I was digging into the project and was trying to figure out how the chunks are set in GCS. After reading this project's code and the GCS SDK's code - I understood how the SDK defaults to resumable uploads. I figured it's useful to explicitly mention how we default to GCS's default when we set it to null and link to the source - for future compatibility, e.g if/when GCS changes their default