### PR TITLE
feat: supports simultaneous upload and download rate limiting

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/RemoteStorageManagerConfig.java
@@ -82,6 +82,11 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
         + "(therefore read from disk) per second. Rate limit must be equal or larger than 1 MiB/sec "
         + "as minimal upload throughput.";
 
+    private static final String GLOBAL_RATE_LIMIT_BYTES_CONFIG = "global.rate.limit.bytes.per.second";
+    private static final String GLOBAL_RATE_LIMIT_BYTES_DOC = "Total byte limit for upload and download "
+        + "(Therefore, read from disk/remote) per second. The rate limit must be equal to or greater than 1 MiB/second "
+        + "as the minimum upload or download throughput.";
+
     public static final String METRICS_NUM_SAMPLES_CONFIG = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
     private static final String METRICS_NUM_SAMPLES_DOC = CommonClientConfigs.METRICS_NUM_SAMPLES_DOC;
 
@@ -197,6 +202,12 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
 
     public OptionalInt uploadRateLimit() {
         return Optional.ofNullable(getInt(UPLOAD_RATE_LIMIT_BYTES_CONFIG)).stream()
+            .mapToInt(Integer::intValue)
+            .findAny();
+    }
+
+    public OptionalInt globalRateLimit() {
+        return Optional.ofNullable(getInt(GLOBAL_RATE_LIMIT_BYTES_CONFIG)).stream()
             .mapToInt(Integer::intValue)
             .findAny();
     }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
@@ -56,7 +56,22 @@ public class FetchChunkEnumeration extends RemoteEnumeration {
     public FetchChunkEnumeration(final ChunkManager chunkManager,
                                  final ObjectKey objectKey,
                                  final SegmentManifest manifest,
-                                 final BytesRange range, final Bucket rateLimitingBucket) {
+                                 final BytesRange range) {
+        this(chunkManager,objectKey,manifest,range,null);
+    }
+
+    /**
+     * @param chunkManager provides chunk input to fetch from
+     * @param objectKey    required by chunkManager
+     * @param manifest     provides to index to build response from
+     * @param range        original offset range start/end position
+     * @param rateLimitingBucket        rate limiting bucket
+     */
+    public FetchChunkEnumeration(final ChunkManager chunkManager,
+                                 final ObjectKey objectKey,
+                                 final SegmentManifest manifest,
+                                 final BytesRange range,
+                                final Bucket rateLimitingBucket) {
         super(rateLimitingBucket);
         this.chunkManager = Objects.requireNonNull(chunkManager, "chunkManager cannot be null");
         this.objectKey = Objects.requireNonNull(objectKey, "objectKey cannot be null");

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/FetchChunkEnumeration.java
@@ -19,7 +19,6 @@ package io.aiven.kafka.tieredstorage.fetch;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/TransformFinisher.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/TransformFinisher.java
@@ -31,6 +31,7 @@ import io.aiven.kafka.tieredstorage.manifest.index.ChunkIndex;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndexBuilder;
 import io.aiven.kafka.tieredstorage.manifest.index.VariableSizeChunkIndexBuilder;
 
+import io.aiven.kafka.tieredstorage.util.RemoteEnumeration;
 import io.github.bucket4j.Bucket;
 
 /**
@@ -44,13 +45,12 @@ import io.github.bucket4j.Bucket;
  * but could also have a single chunk if the chunk size is equal or higher to the original file size.
  * Otherwise, the chunk index will contain more than one chunk.
  */
-public class TransformFinisher implements Enumeration<InputStream> {
+public class TransformFinisher extends RemoteEnumeration {
     private final TransformChunkEnumeration inner;
     private final AbstractChunkIndexBuilder chunkIndexBuilder;
     private final Path originalFilePath;
     private final int originalFileSize;
     private ChunkIndex chunkIndex = null;
-    private final Bucket rateLimitingBucket;
 
     public static Builder newBuilder(final TransformChunkEnumeration inner, final int originalFileSize) {
         return new Builder(inner, originalFileSize);
@@ -63,13 +63,13 @@ public class TransformFinisher implements Enumeration<InputStream> {
         final int originalFileSize,
         final Bucket rateLimitingBucket
     ) {
+        super(rateLimitingBucket);
         this.inner = Objects.requireNonNull(inner, "inner cannot be null");
 
         final int originalChunkSize = chunkingEnabled ? inner.originalChunkSize() : originalFileSize;
         this.chunkIndexBuilder = chunkIndexBuilder(inner, originalChunkSize, originalFileSize);
         this.originalFilePath = originalFilePath;
         this.originalFileSize = originalFileSize;
-        this.rateLimitingBucket = rateLimitingBucket;
     }
 
     private static AbstractChunkIndexBuilder chunkIndexBuilder(
@@ -141,13 +141,6 @@ public class TransformFinisher implements Enumeration<InputStream> {
         } else {
             return maybeToRateLimitedInputStream(new SequenceInputStream(this));
         }
-    }
-
-    private InputStream maybeToRateLimitedInputStream(final InputStream delegated) {
-        if (rateLimitingBucket == null) {
-            return delegated;
-        }
-        return new RateLimitedInputStream(delegated, rateLimitingBucket);
     }
 
     private boolean isBaseTransform() {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/TransformFinisher.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/TransformFinisher.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/util/RemoteEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/util/RemoteEnumeration.java
@@ -35,5 +35,4 @@ public abstract class RemoteEnumeration implements Enumeration<InputStream> {
 		return new RateLimitedInputStream(delegated, rateLimitingBucket);
 	}
 
-
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/util/RemoteEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/util/RemoteEnumeration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aiven.kafka.tieredstorage.util;
+
+import java.io.InputStream;
+import java.util.Enumeration;
+import io.aiven.kafka.tieredstorage.transform.RateLimitedInputStream;
+import io.github.bucket4j.Bucket;
+
+public abstract class RemoteEnumeration implements Enumeration<InputStream> {
+
+	protected final Bucket rateLimitingBucket;
+
+	public RemoteEnumeration(final Bucket rateLimitingBucket) {
+		this.rateLimitingBucket = rateLimitingBucket;
+	}
+
+	protected InputStream maybeToRateLimitedInputStream(final InputStream delegated) {
+		if (rateLimitingBucket == null) {
+			return delegated;
+		}
+		return new RateLimitedInputStream(delegated, rateLimitingBucket);
+	}
+
+
+}


### PR DESCRIPTION
About this change - What it does
The functionality, which originally only limited uploads, has been changed to a global rate limit.


Resolves: 
The purpose of this change is twofold:

When your remote storage service is located in a public cloud, such as AWS S3, and your server is on-premises, pulling data from the remote can easily saturate the local bandwidth, affecting the normal operation of other services.

Generally, AWS EC2's free disk throughput limit is 128MB. When uploading, downloading, and reading from local cache, without a global rate limiter to prevent competition between these operations, disk I/O can become uncontrollable, leading to issues with the producer's write operations.