### PR TITLE
fix: remove listener should not cause exceptions when the file is not present

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DiskChunkCache.java
@@ -100,10 +100,14 @@ public class DiskChunkCache extends ChunkCache<Path> {
             try {
                 if (path != null) {
                     final long fileSize = Files.size(path);
-                    Files.delete(path);
-                    metrics.chunkDeleted(fileSize);
-                    log.trace("Deleted cached file for key {} with path {} from cache directory."
-                        + " The reason of the deletion is {}", key, path, cause);
+                    try {
+                        Files.delete(path);
+                        metrics.chunkDeleted(fileSize);
+                        log.trace("Deleted cached file for key {} with path {} from cache directory."
+                            + " The reason of the deletion is {}", key, path, cause);
+                    } catch (final IOException ex) {
+                        log.warn("Cannot delete file {} for key {}", path, key, ex);
+                    }
                 } else {
                     log.warn("Path not present when trying to delete cached file for key {} from cache directory."
                         + " The reason of the deletion is {}", key, cause);


### PR DESCRIPTION
Sometime `DiskChunkCache.removalListener()` fails with `NoSuchFileException`, it's not yet understood why this happens (could be some race condition), but it's good practice fror a delete operation to not fail if the file to remove is not present. This PR is a slightly less invasive version of https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/pull/569 (less code changed), since the previous PR raised some concerns.

Tested this locally by adding the annotation @RepeatedTest(10000) on `DiskChunkCacheMetricsTest.metrics()`, without my PR sometimes it fails randomly. 