### PR TITLE
MINOR: Correct segment manifest cache size documentation

### DIFF
--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -111,7 +111,7 @@ Under ``fetch.manifest.cache.``
   * Importance: medium
 
 ``size``
-  Cache size in bytes, where "-1" represents unbounded cache
+  The maximum number of entries in the cache, where "-1" represents an unbounded cache.
 
   * Type: long
   * Default: 1000


### PR DESCRIPTION
The `fetch.manifest.cache.size` config [is documented](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/blob/main/docs/configs.rst#segmentmanifestcacheconfig) as the maximum size of the cache in **bytes**. The default is 1KB which sounds super low, so I dug into it.

I notice that this size is [configured via](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/blob/7c09a411f3aac727dd35c4210082ba21b449c94d/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java#L108) `Caffeine.newBuilder().maximumWeight()`.

The _weight_ is [an arbitrary metric defined by the associated weigher method](https://www.javadoc.io/static/com.github.ben-manes.caffeine/caffeine/2.2.0/com/github/benmanes/caffeine/cache/Caffeine.html#maximumWeight-long-). Your weigher metric [gives a value of 1](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/blob/7c09a411f3aac727dd35c4210082ba21b449c94d/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java#L99) per ObjectKey/Manifest pair.

Therefore the segment cache size isn't bytes, it's **the total number of entries**.

This patch corrects the documentation to refer to the accurate meaning of the config.