### PR TITLE
docs: fix segment manifest cache size doc

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/config/CacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/config/CacheConfig.java
@@ -27,7 +27,7 @@ import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
 
 public class CacheConfig extends AbstractConfig {
     private static final String CACHE_SIZE_CONFIG = "size";
-    private static final String CACHE_SIZE_DOC = "Cache size in bytes, where \"-1\" represents unbounded cache";
+    static final String CACHE_SIZE_DOC = "Cache size in bytes, where \"-1\" represents unbounded cache";
     private static final String CACHE_RETENTION_CONFIG = "retention.ms";
     private static final String CACHE_RETENTION_DOC = "Cache retention time ms, "
         + "where \"-1\" represents infinite retention";
@@ -86,6 +86,7 @@ public class CacheConfig extends AbstractConfig {
     public static class DefBuilder {
         private long defaultRetentionMs = CACHE_RETENTION_MS_DEFAULT;
         private Object maybeDefaultSize = NO_DEFAULT_VALUE;
+        private String sizeDoc = CACHE_SIZE_DOC;
 
         final ConfigDef configDef;
 
@@ -107,6 +108,11 @@ public class CacheConfig extends AbstractConfig {
             return this;
         }
 
+        public DefBuilder withSizeDoc(final String sizeDoc) {
+            this.sizeDoc = sizeDoc;
+            return this;
+        }
+
         public ConfigDef build() {
             configDef.define(
                 CACHE_SIZE_CONFIG,
@@ -114,7 +120,7 @@ public class CacheConfig extends AbstractConfig {
                 maybeDefaultSize,
                 ConfigDef.Range.between(-1L, Long.MAX_VALUE),
                 ConfigDef.Importance.MEDIUM,
-                CACHE_SIZE_DOC
+                sizeDoc
             );
             configDef.define(
                 CACHE_RETENTION_CONFIG,

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCache.java
@@ -132,6 +132,7 @@ public class MemorySegmentManifestCache implements SegmentManifestCache {
         return CacheConfig.defBuilder()
             .withDefaultSize(DEFAULT_MAX_SIZE)
             .withDefaultRetentionMs(DEFAULT_RETENTION_MS)
+            .withSizeDoc("The maximum number of entries in the cache, where `-1` represents an unbounded cache.")
             .build();
     }
 }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/config/CacheConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/config/CacheConfigTest.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.tieredstorage.config;
 import java.time.Duration;
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.junit.jupiter.api.Test;
@@ -145,5 +146,15 @@ class CacheConfigTest {
         );
         assertThat(config.threadPoolSize()).hasValue(16);
         assertThat(config.getTimeout()).hasSeconds(20);
+    }
+
+    @Test
+    void setCustomSizeDoc() {
+        final ConfigDef build = CacheConfig.defBuilder()
+            .withSizeDoc("test")
+            .build();
+        assertThat(build.configKeys().get("size").documentation)
+            .isNotEqualTo(CacheConfig.CACHE_SIZE_DOC)
+            .isEqualTo("test");
     }
 }

--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -111,7 +111,7 @@ Under ``fetch.manifest.cache.``
   * Importance: medium
 
 ``size``
-  Cache size in bytes, where "-1" represents unbounded cache
+  The maximum number of entries in the cache, where `-1` represents an unbounded cache.
 
   * Type: long
   * Default: 1000


### PR DESCRIPTION
The doc suggested that cache size is measured in bytes however it's measured in units.