### PR TITLE
chore(build): publish to sonatype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ subprojects {
     apply plugin: 'info.solidsoft.pitest'
 
     apply plugin: "maven-publish"
+    apply plugin: "signing"
 
     repositories {
         // Use Maven Central for resolving dependencies.
@@ -224,12 +225,75 @@ subprojects {
     }
 
     publishing {
+        repositories {
+            maven {
+                name="sonatype"
+
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+                credentials(PasswordCredentials)
+            }
+        }
         publications {
             mavenJava(MavenPublication) {
                 from components.java
+
+                pom {
+                    url = "https://github.com/Aiven-Open/tiered-storage-for-apache-kafka"
+                    organization {
+                        name = "Aiven Oy"
+                        url = "https://aiven.io"
+                    }
+
+                    licenses {
+                        license {
+                            name = "Apache 2.0"
+                            url = "http://www.apache.org/licenses/LICENSE-2.0"
+                            distribution = "repo"
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id = 'aiven'
+                            name = 'Aiven Opensource'
+                            email = 'opensource@aiven.io'
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:git://github.com:Aiven-Open/tiered-storage-for-apache-kafka.git'
+                        developerConnection = 'scm:git:ssh://github.com:Aiven-Open/tiered-storage-for-apache-kafka.git'
+                        url = 'https://github.com/Aiven-Open/tiered-storage-for-apache-kafka'
+                    }
+                }
+
                 afterEvaluate {
                     groupId = "io.aiven"
                     artifactId = "tiered-storage-for-apache-kafka-${archivesBaseName}"
+                }
+            }
+        }
+
+        signing {
+            sign publishing.publications.mavenJava
+            useGpgCmd()
+            // Some issue in the plugin:
+            // GPG outputs already armored signatures. The plugin also does armoring for `asc` files.
+            // This results in double armored signatures, i.e. garbage.
+            // Override the signature type provider to use unarmored output for `asc` files, which works well with GPG.
+            signatureTypes = new AbstractSignatureTypeProvider() {
+                {
+                    BinarySignatureType binary = new BinarySignatureType() {
+                        @Override
+                        String getExtension() {
+                            return "asc"
+                        }
+                    }
+                    register(binary)
+                    setDefaultType(binary.getExtension())
                 }
             }
         }
@@ -299,3 +363,52 @@ tasks.register('validateDependencies') {
 //tasks.named("check") {
 //    dependsOn(tasks.named("validateDependencies"))
 //}
+
+// Define the list of modules to be published
+def modulesToPublish = [
+        ':commons',
+        ':core',
+        ':storage:core',
+        ':storage:filesystem',
+        ':storage:s3',
+        ':storage:gcs',
+        ':storage:azure',
+]
+
+// Include root project in the list if needed
+// modulesToPublish.add(0, ':')  // Uncomment this line if you want to include root project
+
+// Register the task first
+tasks.register("publishToSonatype") {
+    description = 'Publishes selected modules to Sonatype repository'
+    group = 'publishing'
+
+    doFirst {
+        println "Publishing selected modules to Sonatype..."
+    }
+}
+
+// Add the dependency on distTar
+tasks.named("publishToSonatype") {
+    dependsOn(tasks.named("distTar"))
+}
+
+// Configure the task after all projects have been evaluated
+gradle.projectsEvaluated {
+    tasks.named("publishToSonatype") {
+        modulesToPublish.each { modulePath ->
+            def moduleProject = modulePath == ':' ? rootProject : project(modulePath)
+            def taskName = modulePath == ':' ?
+                    'publishMavenPublicationToSonatypeRepository' :
+                    'publishMavenJavaPublicationToSonatypeRepository'
+
+            def publishTask = moduleProject.tasks.findByName(taskName)
+            if (publishTask) {
+                dependsOn publishTask
+                println "Added ${moduleProject.path}:${taskName}"
+            } else {
+                println "Warning: Publication task not found for ${modulePath}"
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -298,6 +298,20 @@ subprojects {
             }
         }
     }
+
+    // Skip test fixtures from distribution archives
+    afterEvaluate { proj ->
+        // Skip test fixtures from distributions
+        proj.distributions.all {
+            contents {
+                // Exclude any test fixtures JARs from the distribution
+                exclude { element ->
+                    element.file.name.contains('test-fixtures')
+                    element.file.name.contains('sources')
+                }
+            }
+        }
+    }
 }
 
 distributions {
@@ -375,38 +389,28 @@ def modulesToPublish = [
         ':storage:azure',
 ]
 
-// Include root project in the list if needed
-// modulesToPublish.add(0, ':')  // Uncomment this line if you want to include root project
-
-// Register the task first
+// Define and configure the publishToSonatype task
 tasks.register("publishToSonatype") {
     description = 'Publishes selected modules to Sonatype repository'
     group = 'publishing'
+    dependsOn(tasks.named("distTar"))
 
     doFirst {
         println "Publishing selected modules to Sonatype..."
     }
 }
 
-// Add the dependency on distTar
-tasks.named("publishToSonatype") {
-    dependsOn(tasks.named("distTar"))
-}
-
-// Configure the task after all projects have been evaluated
+// Configure task dependencies after all projects are evaluated
 gradle.projectsEvaluated {
     tasks.named("publishToSonatype") {
         modulesToPublish.each { modulePath ->
             def moduleProject = modulePath == ':' ? rootProject : project(modulePath)
-            def taskName = modulePath == ':' ?
-                    'publishMavenPublicationToSonatypeRepository' :
-                    'publishMavenJavaPublicationToSonatypeRepository'
+            def taskName = "${moduleProject.path}:publish${modulePath == ':' ? 'Maven' : 'MavenJava'}PublicationToSonatypeRepository"
 
-            def publishTask = moduleProject.tasks.findByName(taskName)
-            if (publishTask) {
-                dependsOn publishTask
-                println "Added ${moduleProject.path}:${taskName}"
-            } else {
+            try {
+                dependsOn(taskName)
+                println "Added $taskName"
+            } catch (Exception e) {
                 println "Warning: Publication task not found for ${modulePath}"
             }
         }

--- a/storage/core/build.gradle
+++ b/storage/core/build.gradle
@@ -33,7 +33,3 @@ dependencies {
 
     testFixturesImplementation "org.testcontainers:junit-jupiter:$testcontainersVersion"
 }
-
-components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
-components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }
-


### PR DESCRIPTION
This change includes:

- Add signing plugin
- Add sonatype repo
- Include maven pom properties to be published
- Task to publish specific modules
- Allowed test-fixture jars to be included in the package (requested here: https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/pull/583#issuecomment-2694522529). Instead filter-out test-fixtures and sources from distributions

I have tested the publishing to sonatype with snapshots and it's looking good: https://oss.sonatype.org/service/local/repositories/snapshots/content/io/aiven/tiered-storage-for-apache-kafka-storage-core/0.0.1-SNAPSHOT/tiered-storage-for-apache-kafka-storage-core-0.0.1-20250306.172800-8-test-fixtures.jar