### PR TITLE
Support setting storage class for S3 to reduce cost

### DIFF
--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -496,7 +496,7 @@ S3StorageConfig
   * Importance: low
 
 ``s3.storage.class``
-  S3 storage class to store log segments
+  Defines which storage class to use when uploading objects
 
   * Type: string
   * Default: STANDARD

--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -449,6 +449,14 @@ S3StorageConfig
   * Valid Values: [5242880,...,2147483647]
   * Importance: medium
 
+``s3.storage.class``
+  S3 storage class to store log segments
+
+  * Type: string
+  * Default: STANDARD
+  * Valid Values: [STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE]
+  * Importance: medium
+
 ``aws.certificate.check.enabled``
   This property is used to enable SSL certificate checking for AWS services. When set to "false", the SSL certificate checking for AWS services will be bypassed. Use with caution and always only in a test environment, as disabling certificate lead the storage to be vulnerable to man-in-the-middle attacks.
 

--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -449,14 +449,6 @@ S3StorageConfig
   * Valid Values: [5242880,...,2147483647]
   * Importance: medium
 
-``s3.storage.class``
-  S3 storage class to store log segments
-
-  * Type: string
-  * Default: STANDARD
-  * Valid Values: [STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE]
-  * Importance: medium
-
 ``aws.certificate.check.enabled``
   This property is used to enable SSL certificate checking for AWS services. When set to "false", the SSL certificate checking for AWS services will be bypassed. Use with caution and always only in a test environment, as disabling certificate lead the storage to be vulnerable to man-in-the-middle attacks.
 
@@ -501,6 +493,14 @@ S3StorageConfig
 
   * Type: boolean
   * Default: null
+  * Importance: low
+
+``s3.storage.class``
+  S3 storage class to store log segments
+
+  * Type: string
+  * Default: STANDARD
+  * Valid Values: [STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE]
   * Importance: low
 
 

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -83,8 +83,8 @@ public class S3MultiPartOutputStream extends OutputStream {
         this.partSize = partSize;
         this.partBuffer = ByteBuffer.allocate(partSize);
         final CreateMultipartUploadRequest initialRequest = CreateMultipartUploadRequest.builder().bucket(bucketName)
-                .storageClass(storageClass)
-                .key(key.value()).build();
+            .storageClass(storageClass)
+            .key(key.value()).build();
         final CreateMultipartUploadResponse initiateResult = client.createMultipartUpload(initialRequest);
         log.debug("Create new multipart upload request: {}", initiateResult.uploadId());
         this.uploadId = initiateResult.uploadId();

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
@@ -64,17 +65,16 @@ public class S3MultiPartOutputStream extends OutputStream {
     private boolean closed;
     private long processedBytes;
 
-
     public S3MultiPartOutputStream(final String bucketName,
                                    final ObjectKey key,
                                    final int partSize,
                                    final S3Client client){
-        this(bucketName, key, S3StorageConfig.S3_STORAGE_CLASS_DEFAULT, partSize, client);
+        this(bucketName, key, StorageClass.STANDARD, partSize, client);
     }
 
     public S3MultiPartOutputStream(final String bucketName,
                                    final ObjectKey key,
-                                   final String storageClass,
+                                   final StorageClass storageClass,
                                    final int partSize,
                                    final S3Client client) {
         this.bucketName = bucketName;

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -64,8 +64,17 @@ public class S3MultiPartOutputStream extends OutputStream {
     private boolean closed;
     private long processedBytes;
 
+
     public S3MultiPartOutputStream(final String bucketName,
                                    final ObjectKey key,
+                                   final int partSize,
+                                   final S3Client client){
+        this(bucketName, key, S3StorageConfig.S3_STORAGE_CLASS_DEFAULT, partSize, client);
+    }
+
+    public S3MultiPartOutputStream(final String bucketName,
+                                   final ObjectKey key,
+                                   final String storageClass,
                                    final int partSize,
                                    final S3Client client) {
         this.bucketName = bucketName;
@@ -74,7 +83,8 @@ public class S3MultiPartOutputStream extends OutputStream {
         this.partSize = partSize;
         this.partBuffer = ByteBuffer.allocate(partSize);
         final CreateMultipartUploadRequest initialRequest = CreateMultipartUploadRequest.builder().bucket(bucketName)
-            .key(key.value()).build();
+                .storageClass(storageClass)
+                .key(key.value()).build();
         final CreateMultipartUploadResponse initiateResult = client.createMultipartUpload(initialRequest);
         log.debug("Create new multipart upload request: {}", initiateResult.uploadId());
         this.uploadId = initiateResult.uploadId();

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 
 public class S3Storage implements StorageBackend {
     private static final int MAX_DELETE_OBJECTS = 1000;
@@ -47,8 +48,7 @@ public class S3Storage implements StorageBackend {
     S3Client s3Client;
 
     private String bucketName;
-
-    private String storageClass;
+    private StorageClass storageClass;
     private int partSize;
 
     @Override

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
@@ -47,6 +47,8 @@ public class S3Storage implements StorageBackend {
     S3Client s3Client;
 
     private String bucketName;
+
+    private String storageClass;
     private int partSize;
 
     @Override
@@ -54,6 +56,7 @@ public class S3Storage implements StorageBackend {
         final S3StorageConfig config = new S3StorageConfig(configs);
         this.s3Client = S3ClientBuilder.build(config);
         this.bucketName = config.bucketName();
+        this.storageClass = config.storageClass();
         this.partSize = config.uploadPartSize();
     }
 
@@ -70,7 +73,7 @@ public class S3Storage implements StorageBackend {
     }
 
     S3MultiPartOutputStream s3OutputStream(final ObjectKey key) {
-        return new S3MultiPartOutputStream(bucketName, key, partSize, s3Client);
+        return new S3MultiPartOutputStream(bucketName, key, storageClass, partSize, s3Client);
     }
 
     @Override

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -124,7 +124,8 @@ public class S3StorageConfig extends AbstractConfig {
                 S3_STORAGE_CLASS_CONFIG,
                 ConfigDef.Type.STRING,
                 S3_STORAGE_CLASS_DEFAULT,
-                ConfigDef.ValidString.in(StorageClass.knownValues().stream().map(Object::toString).toArray(String[]::new)),
+                ConfigDef.ValidString.in(StorageClass.knownValues()
+                        .stream().map(Object::toString).toArray(String[]::new)),
                 ConfigDef.Importance.MEDIUM,
                 S3_STORAGE_CLASS_DOC)
             .define(

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -126,7 +126,7 @@ public class S3StorageConfig extends AbstractConfig {
                 S3_STORAGE_CLASS_DEFAULT,
                 ConfigDef.ValidString.in(StorageClass.knownValues()
                         .stream().map(Object::toString).toArray(String[]::new)),
-                ConfigDef.Importance.MEDIUM,
+                ConfigDef.Importance.LOW,
                 S3_STORAGE_CLASS_DOC)
             .define(
                 S3_PATH_STYLE_ENABLED_CONFIG,
@@ -271,8 +271,8 @@ public class S3StorageConfig extends AbstractConfig {
         return getString(S3_BUCKET_NAME_CONFIG);
     }
 
-    public String storageClass() {
-        return getString(S3_STORAGE_CLASS_CONFIG);
+    public StorageClass storageClass() {
+        return StorageClass.valueOf(getString(S3_STORAGE_CLASS_CONFIG));
     }
 
     public Boolean pathStyleAccessEnabled() {

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -51,7 +51,7 @@ public class S3StorageConfig extends AbstractConfig {
     private static final String S3_REGION_DOC = "AWS region where S3 bucket is placed";
 
     public static final String S3_STORAGE_CLASS_CONFIG = "s3.storage.class";
-    private static final String S3_STORAGE_CLASS_DOC = "S3 storage class to store log segments";
+    private static final String S3_STORAGE_CLASS_DOC = "Defines which storage class to use when uploading objects";
     static final String S3_STORAGE_CLASS_DEFAULT = StorageClass.STANDARD.toString();
 
     static final String S3_PATH_STYLE_ENABLED_CONFIG = "s3.path.style.access.enabled";

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.utils.builder.Buildable;
 
 public class S3StorageConfig extends AbstractConfig {
@@ -48,6 +49,11 @@ public class S3StorageConfig extends AbstractConfig {
         + "To be used with custom S3-compatible backends (e.g. minio).";
     public static final String S3_REGION_CONFIG = "s3.region";
     private static final String S3_REGION_DOC = "AWS region where S3 bucket is placed";
+
+    public static final String S3_STORAGE_CLASS_CONFIG = "s3.storage.class";
+    private static final String S3_STORAGE_CLASS_DOC = "S3 storage class to store log segments";
+    static final String S3_STORAGE_CLASS_DEFAULT = StorageClass.STANDARD.toString();
+
     static final String S3_PATH_STYLE_ENABLED_CONFIG = "s3.path.style.access.enabled";
     private static final String S3_PATH_STYLE_ENABLED_DOC = "Whether to use path style access or virtual hosts. "
         + "By default, empty value means S3 library will auto-detect. "
@@ -114,6 +120,13 @@ public class S3StorageConfig extends AbstractConfig {
                 ConfigDef.NO_DEFAULT_VALUE,
                 ConfigDef.Importance.MEDIUM,
                 S3_REGION_DOC)
+            .define(
+                S3_STORAGE_CLASS_CONFIG,
+                ConfigDef.Type.STRING,
+                S3_STORAGE_CLASS_DEFAULT,
+                ConfigDef.ValidString.in(StorageClass.knownValues().stream().map(Object::toString).toArray(String[]::new)),
+                ConfigDef.Importance.MEDIUM,
+                S3_STORAGE_CLASS_DOC)
             .define(
                 S3_PATH_STYLE_ENABLED_CONFIG,
                 ConfigDef.Type.BOOLEAN,
@@ -255,6 +268,10 @@ public class S3StorageConfig extends AbstractConfig {
 
     public String bucketName() {
         return getString(S3_BUCKET_NAME_CONFIG);
+    }
+
+    public String storageClass() {
+        return getString(S3_STORAGE_CLASS_CONFIG);
     }
 
     public Boolean pathStyleAccessEnabled() {

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
@@ -254,8 +254,8 @@ class S3StorageConfigTest {
                 "s3.storage.class", "WrongStorageClass"
         )))
                 .isInstanceOf(ConfigException.class)
-                .hasMessage("Invalid value WrongStorageClass for configuration s3.storage.class: " +
-                        "String must be one of: STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, " +
-                        "INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE");
+                .hasMessage("Invalid value WrongStorageClass for configuration s3.storage.class: "
+                        + "String must be one of: STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, "
+                        + "INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE");
     }
 }

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
@@ -30,7 +30,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 
 import static io.aiven.kafka.tieredstorage.storage.s3.S3StorageConfig.S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT;
-import static io.aiven.kafka.tieredstorage.storage.s3.S3StorageConfig.S3_STORAGE_CLASS_DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -53,7 +52,7 @@ class S3StorageConfigTest {
         assertThat(config.credentialsProvider()).isNull();
         assertThat(config.pathStyleAccessEnabled()).isNull();
         assertThat(config.uploadPartSize()).isEqualTo(S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT);
-        assertThat(config.storageClass()).isEqualTo(S3_STORAGE_CLASS_DEFAULT);
+        assertThat(config.storageClass()).isEqualTo(StorageClass.STANDARD);
         assertThat(config.certificateCheckEnabled()).isTrue();
         assertThat(config.checksumCheckEnabled()).isFalse();
         assertThat(config.region()).isEqualTo(TEST_REGION);
@@ -238,20 +237,20 @@ class S3StorageConfigTest {
     @Test
     void withStorageClass() {
         final var configs = Map.of(
-                "s3.bucket.name", BUCKET_NAME,
-                "s3.region", TEST_REGION.id(),
-                "s3.storage.class", StorageClass.STANDARD_IA.toString()
+            "s3.bucket.name", BUCKET_NAME,
+            "s3.region", TEST_REGION.id(),
+            "s3.storage.class", StorageClass.STANDARD_IA.toString()
         );
         final var config = new S3StorageConfig(configs);
-        assertThat(config.storageClass()).isEqualTo(StorageClass.STANDARD_IA.toString());
+        assertThat(config.storageClass()).isEqualTo(StorageClass.STANDARD_IA);
     }
 
     @Test
     void withRequireStorageClassInAllowList() {
         assertThatThrownBy(() -> new S3StorageConfig(Map.of(
-                "s3.bucket.name", BUCKET_NAME,
-                "s3.region", TEST_REGION.id(),
-                "s3.storage.class", "WrongStorageClass"
+            "s3.bucket.name", BUCKET_NAME,
+            "s3.region", TEST_REGION.id(),
+            "s3.storage.class", "WrongStorageClass"
         )))
                 .isInstanceOf(ConfigException.class)
                 .hasMessage("Invalid value WrongStorageClass for configuration s3.storage.class: "

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfigTest.java
@@ -27,8 +27,10 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.StorageClass;
 
 import static io.aiven.kafka.tieredstorage.storage.s3.S3StorageConfig.S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT;
+import static io.aiven.kafka.tieredstorage.storage.s3.S3StorageConfig.S3_STORAGE_CLASS_DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -51,6 +53,7 @@ class S3StorageConfigTest {
         assertThat(config.credentialsProvider()).isNull();
         assertThat(config.pathStyleAccessEnabled()).isNull();
         assertThat(config.uploadPartSize()).isEqualTo(S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT);
+        assertThat(config.storageClass()).isEqualTo(S3_STORAGE_CLASS_DEFAULT);
         assertThat(config.certificateCheckEnabled()).isTrue();
         assertThat(config.checksumCheckEnabled()).isFalse();
         assertThat(config.region()).isEqualTo(TEST_REGION);
@@ -230,5 +233,29 @@ class S3StorageConfigTest {
         final var config = new S3StorageConfig(configs);
         assertThat(config.apiCallTimeout()).isEqualTo(Duration.ofMillis(5000));
         assertThat(config.apiCallAttemptTimeout()).isEqualTo(Duration.ofMillis(1000));
+    }
+
+    @Test
+    void withStorageClass() {
+        final var configs = Map.of(
+                "s3.bucket.name", BUCKET_NAME,
+                "s3.region", TEST_REGION.id(),
+                "s3.storage.class", StorageClass.STANDARD_IA.toString()
+        );
+        final var config = new S3StorageConfig(configs);
+        assertThat(config.storageClass()).isEqualTo(StorageClass.STANDARD_IA.toString());
+    }
+
+    @Test
+    void withRequireStorageClassInAllowList() {
+        assertThatThrownBy(() -> new S3StorageConfig(Map.of(
+                "s3.bucket.name", BUCKET_NAME,
+                "s3.region", TEST_REGION.id(),
+                "s3.storage.class", "WrongStorageClass"
+        )))
+                .isInstanceOf(ConfigException.class)
+                .hasMessage("Invalid value WrongStorageClass for configuration s3.storage.class: " +
+                        "String must be one of: STANDARD, REDUCED_REDUNDANCY, STANDARD_IA, ONEZONE_IA, " +
+                        "INTELLIGENT_TIERING, GLACIER, DEEP_ARCHIVE, OUTPOSTS, GLACIER_IR, SNOW, EXPRESS_ONEZONE");
     }
 }


### PR DESCRIPTION
Hi Team:

Thanks for provide so cool tool to support kafka tiered-storage. 

Refer to the document: 
https://aws.amazon.com/s3/storage-classes/?nc1=h_ls
We can know the storage class feature is the core important feature for s3 which involve the cost and performance.
We had adopt tiered storage implement in our Kafka for cost saving goal. thus, we find that all of the Kafka data uploaded by the standard default storage class. So try to create this PR to support the setting for storage class. So that we can get more cost saving.

Thanks in advanced.  WDYT?

FYI:
![image](https://github.com/user-attachments/assets/38a3ec17-b7bb-4676-8b26-9b21eeb3fae5)
![image](https://github.com/user-attachments/assets/ef279226-5f83-4563-96a4-b297df4157c4)
![image](https://github.com/user-attachments/assets/77f97426-8f15-4667-b82f-307c1f9be850)
