### PR TITLE
Improve the s3 upload logic to reduce requests and fix retry fail issue

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -18,6 +18,7 @@
         "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
+    <suppress checks="RegexpHeader" files="ByteBufferMarkableInputStream.java"/>
     <suppress checks="AbbreviationAsWordInName" files="DataKeyAndAADEqualsTest"/>
     <suppress checks="ClassDataAbstractionCoupling" files=".*Test\.java"/>
     <suppress checks="ClassFanOutComplexity" files=".*Test\.java"/>

--- a/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/BaseStorageTest.java
+++ b/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/BaseStorageTest.java
@@ -64,6 +64,10 @@ public abstract class BaseStorageTest {
     @Test
     void testUploadANewFile() throws StorageBackendException, IOException {
         final String content = "content";
+        uploadContentAsFileAndVerify(content);
+    }
+
+    protected void uploadContentAsFileAndVerify(final String content) throws StorageBackendException, IOException {
         final ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes());
         final long size = storage().upload(in, TOPIC_PARTITION_SEGMENT_KEY);
         assertThat(size).isEqualTo(content.length());

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/ByteBufferMarkableInputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/ByteBufferMarkableInputStream.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2025 Aiven Oy
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/ByteBufferMarkableInputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/ByteBufferMarkableInputStream.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.s3;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Wraps a {@link ByteBuffer} for access via the {@link InputStream} API.
+ * Its implement refers to {@link org.apache.kafka.common.utils.ByteBufferInputStream}
+ * but with marking and resetting operations added.
+ */
+public class ByteBufferMarkableInputStream extends InputStream {
+    private final ByteBuffer byteBuffer;
+
+    public ByteBufferMarkableInputStream(final ByteBuffer buffer) {
+        byteBuffer = Objects.requireNonNull(buffer);
+    }
+
+    public int read() {
+        return !this.byteBuffer.hasRemaining() ? -1 : this.byteBuffer.get() & 255;
+    }
+
+    public int read(final byte[] bytes, final int off, int len) {
+        if (len == 0) {
+            return 0;
+        } else if (!this.byteBuffer.hasRemaining()) {
+            return -1;
+        } else {
+            len = Math.min(len, this.byteBuffer.remaining());
+            this.byteBuffer.get(bytes, off, len);
+            return len;
+        }
+    }
+
+    public int available() {
+        return this.byteBuffer.remaining();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public void mark(final int readLimit) {
+        byteBuffer.mark();
+    }
+
+    @Override
+    public void reset() {
+        byteBuffer.reset();
+    }
+}

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
@@ -72,8 +72,8 @@ public class S3Storage implements StorageBackend {
         return out.processedBytes();
     }
 
-    S3MultiPartOutputStream s3OutputStream(final ObjectKey key) {
-        return new S3MultiPartOutputStream(bucketName, key, storageClass, partSize, s3Client);
+    S3UploadOutputStream s3OutputStream(final ObjectKey key) {
+        return new S3UploadOutputStream(bucketName, key, storageClass, partSize, s3Client);
     }
 
     @Override

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.kafka.common.utils.ByteBufferInputStream;
 
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 
@@ -233,7 +232,9 @@ public class S3UploadOutputStream extends OutputStream {
     private void flushBuffer(final ByteBuffer buffer,
                              final int actualPartSize,
                              final boolean multiPartUpload) {
-        try (final InputStream in = new ByteBufferInputStream(buffer)) {
+        //When building the retry request for fail or computing checksum for request body,
+        //It needs the input stream supporting marking and resetting so that it can be read again.
+        try (final InputStream in = new ByteBufferMarkableInputStream(buffer)) {
             processedBytes += actualPartSize;
             if (multiPartUpload){
                 uploadPart(in, actualPartSize);

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/ByteBufferMarkableInputStreamTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/ByteBufferMarkableInputStreamTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.storage.s3;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ByteBufferMarkableInputStreamTest {
+
+    @Test
+    void readAfterAllBytesReadWithoutReset() throws IOException {
+        final byte[] buffer = new byte[10];
+        new Random().nextBytes(buffer);
+        try (ByteBufferMarkableInputStream inputStream = new ByteBufferMarkableInputStream(ByteBuffer.wrap(buffer))){
+            assertThat(inputStream.markSupported()).isTrue();
+            assertThat(inputStream.available()).isEqualTo(10);
+            inputStream.readAllBytes();
+            assertThat(inputStream.available()).isEqualTo(0);
+            final int read = inputStream.read();
+            assertThat(read).isEqualTo(-1);
+        }
+    }
+
+    @Test
+    void readAfterAllBytesReadAndReset() throws IOException {
+        final byte[] buffer = new byte[10];
+        new Random().nextBytes(buffer);
+        try (ByteBufferMarkableInputStream inputStream = new ByteBufferMarkableInputStream(ByteBuffer.wrap(buffer))){
+            inputStream.mark(0);
+            inputStream.readAllBytes();
+            assertThat(inputStream.available()).isEqualTo(0);
+            //reset and try to read again
+            inputStream.reset();
+            assertThat(inputStream.available()).isEqualTo(10);
+            final int read = inputStream.read();
+            assertThat(read).isNotEqualTo(-1);
+        }
+    }
+}

--- a/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStreamTest.java
+++ b/storage/s3/src/test/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStreamTest.java
@@ -42,6 +42,8 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
@@ -50,13 +52,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class S3MultiPartOutputStreamTest {
+class S3UploadOutputStreamTest {
     private static final String BUCKET_NAME = "some_bucket";
     private static final ObjectKey FILE_KEY = new TestObjectKey("some_key");
     private static final String UPLOAD_ID = "some_upload_id";
@@ -73,27 +76,38 @@ class S3MultiPartOutputStreamTest {
     @Captor
     ArgumentCaptor<UploadPartRequest> uploadPartRequestCaptor;
     @Captor
+    ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor;
+    @Captor
     ArgumentCaptor<RequestBody> requestBodyCaptor;
 
     final Random random = new Random();
 
     @BeforeEach
     void setUp() {
-        when(mockedS3.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
+        //In most cases, this stub is needed, except for a few.
+        //So, add 'lenient' to bypass strict stubbing.
+        lenient().when(mockedS3.createMultipartUpload(any(CreateMultipartUploadRequest.class)))
             .thenReturn(newInitiateMultipartUploadResult());
     }
 
     @Test
-    void completeMultipartUploadWithDefaultStorageClass() {
-        new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 1, mockedS3);
+    void completeMultipartUploadWithDefaultStorageClass() throws IOException {
+        final S3UploadOutputStream s3UploadOutputStream = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 1, mockedS3);
+        when(mockedS3.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+            .thenReturn(newUploadPartResponse("SOME_ETAG#1"));
+        s3UploadOutputStream.write(1);
         verify(mockedS3).createMultipartUpload(createMultipartUploadRequest.capture());
         assertCreateMultipartUploadRequest(createMultipartUploadRequest.getValue(), StorageClass.STANDARD);
     }
 
     @Test
-    void completeMultipartUploadWithNonDefaultStorageClass() {
+    void completeMultipartUploadWithNonDefaultStorageClass() throws IOException {
         final StorageClass nonDefaultStorageClass = StorageClass.STANDARD_IA;
-        new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, nonDefaultStorageClass, 1, mockedS3);
+        final S3UploadOutputStream s3UploadOutputStream = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY,
+            nonDefaultStorageClass, 1, mockedS3);
+        when(mockedS3.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+            .thenReturn(newUploadPartResponse("SOME_ETAG#1"));
+        s3UploadOutputStream.write(1);
         verify(mockedS3).createMultipartUpload(createMultipartUploadRequest.capture());
         assertCreateMultipartUploadRequest(createMultipartUploadRequest.getValue(), nonDefaultStorageClass);
     }
@@ -104,7 +118,7 @@ class S3MultiPartOutputStreamTest {
         when(mockedS3.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
             .thenThrow(testException);
 
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 1, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 1, mockedS3);
         assertThatThrownBy(() -> out.write(new byte[] {1, 2, 3}))
             .isInstanceOf(IOException.class)
             .hasRootCause(testException);
@@ -124,11 +138,12 @@ class S3MultiPartOutputStreamTest {
     @Test
     void sendAbortForAnyExceptionWhenClosingUpload() throws Exception {
         when(mockedS3.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
+            .thenReturn(newUploadPartResponse("SOME_ETAG#1"))
             .thenThrow(RuntimeException.class);
 
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 10, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 10, mockedS3);
 
-        final byte[] buffer = new byte[5];
+        final byte[] buffer = new byte[15];
         random.nextBytes(buffer);
         out.write(buffer, 0, buffer.length);
 
@@ -153,9 +168,9 @@ class S3MultiPartOutputStreamTest {
         when(mockedS3.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
             .thenThrow(RuntimeException.class);
 
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 10, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 10, mockedS3);
 
-        final byte[] buffer = new byte[5];
+        final byte[] buffer = new byte[10];
         random.nextBytes(buffer);
         out.write(buffer, 0, buffer.length);
 
@@ -174,14 +189,14 @@ class S3MultiPartOutputStreamTest {
     }
 
     @Test
-    void writesOneByte() throws Exception {
+    void writesOnePartUploadByte() throws Exception {
         when(mockedS3.uploadPart(any(UploadPartRequest.class), any(RequestBody.class)))
             .thenReturn(newUploadPartResponse("SOME_ETAG"));
         when(mockedS3.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
             .thenReturn(CompleteMultipartUploadResponse.builder().eTag("SOME_ETAG").build());
 
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 100, mockedS3);
-        out.write(1);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 1, mockedS3);
+        out.write(new byte[] {1});
         out.close();
 
         assertThat(out.isClosed()).isTrue();
@@ -202,6 +217,24 @@ class S3MultiPartOutputStreamTest {
             completeMultipartUploadRequestCaptor.getValue(),
             List.of(CompletedPart.builder().partNumber(1).eTag("SOME_ETAG").build())
         );
+    }
+
+    @Test
+    void writesSmallFile() throws Exception {
+        when(mockedS3.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(newPutObjectResponse("SOME_ETAG"));
+
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 2, mockedS3);
+        out.write(new byte[] {1});
+        out.close();
+
+        assertThat(out.isClosed()).isTrue();
+        assertThatCode(out::close).doesNotThrowAnyException();
+
+        verify(mockedS3).putObject(putObjectRequestCaptor.capture(), requestBodyCaptor.capture());
+        verify(mockedS3, never()).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+        verify(mockedS3, never()).createMultipartUpload(any(CreateMultipartUploadRequest.class));
+        verify(mockedS3, never()).uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
     }
 
     @Test
@@ -227,7 +260,7 @@ class S3MultiPartOutputStreamTest {
             .thenReturn(CompleteMultipartUploadResponse.builder().build());
 
         final List<byte[]> expectedMessagesList = new ArrayList<>();
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, bufferSize, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, bufferSize, mockedS3);
         for (int i = 0; i < 3; i++) {
             final byte[] message = new byte[bufferSize];
             random.nextBytes(message);
@@ -288,7 +321,7 @@ class S3MultiPartOutputStreamTest {
         final byte[] expectedFullMessage = new byte[messageSize + 10];
         final byte[] expectedTailMessage = new byte[10];
 
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, messageSize + 10, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, messageSize + 10, mockedS3);
         final byte[] message = new byte[messageSize];
         random.nextBytes(message);
         out.write(message);
@@ -352,7 +385,7 @@ class S3MultiPartOutputStreamTest {
         System.arraycopy(message1, 0, expectedFullMessage1, 2, 6);
         System.arraycopy(message1, 6, expectedTailMessage, 0, 4);
         final var in = new SequenceInputStream(new ByteArrayInputStream(message0), new ByteArrayInputStream(message1));
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 8, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 8, mockedS3);
         try (in; out) {
             in.transferTo(out);
         }
@@ -410,7 +443,7 @@ class S3MultiPartOutputStreamTest {
         System.arraycopy(message1, 0, expectedFullMessage0, 10, 2);
         System.arraycopy(message1, 2, expectedTailMessage, 0, 8);
         final var in = new SequenceInputStream(new ByteArrayInputStream(message0), new ByteArrayInputStream(message1));
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 12, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 12, mockedS3);
         try (in; out) {
             in.transferTo(out);
         }
@@ -434,23 +467,21 @@ class S3MultiPartOutputStreamTest {
     }
 
     @Test
-    void sendAbortIfNoWritingHappened() throws IOException {
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 100, mockedS3);
+    void closeNormallyIfNoWritingHappened() throws IOException {
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 100, mockedS3);
         out.close();
 
-        verify(mockedS3).abortMultipartUpload(abortMultipartUploadRequestCaptor.capture());
-        assertAbortMultipartUploadRequest(abortMultipartUploadRequestCaptor.getValue());
+        verify(mockedS3, never()).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
         assertThat(out.isClosed()).isTrue();
         assertThatCode(out::close).doesNotThrowAnyException();
     }
 
     @Test
     void failWhenUploadingPartAfterStreamIsClosed() throws IOException {
-        final var out = new S3MultiPartOutputStream(BUCKET_NAME, FILE_KEY, 100, mockedS3);
+        final var out = new S3UploadOutputStream(BUCKET_NAME, FILE_KEY, 100, mockedS3);
         out.close();
 
-        verify(mockedS3).abortMultipartUpload(abortMultipartUploadRequestCaptor.capture());
-        assertAbortMultipartUploadRequest(abortMultipartUploadRequestCaptor.getValue());
+        verify(mockedS3, never()).abortMultipartUpload(abortMultipartUploadRequestCaptor.capture());
         assertThat(out.isClosed()).isTrue();
         assertThatCode(out::close).doesNotThrowAnyException();
 
@@ -467,6 +498,10 @@ class S3MultiPartOutputStreamTest {
 
     private static UploadPartResponse newUploadPartResponse(final String etag) {
         return UploadPartResponse.builder().eTag(etag).build();
+    }
+
+    private static PutObjectResponse newPutObjectResponse(final String etag) {
+        return PutObjectResponse.builder().eTag(etag).build();
     }
 
     private static void assertCreateMultipartUploadRequest(final CreateMultipartUploadRequest request,


### PR DESCRIPTION
### Part 1:  reduce s3 request for small file
Kafka have three type of the files which need to upload as followed:
![image](https://github.com/user-attachments/assets/c1e6e125-dbef-400e-8173-86fa51978f42)

Most of file with the type("rsm-manifest" and "indexes") don't have > 5M size (Which is the default upload part size). So for these type of the files and some small size log segement. There is no need to upload by multipart. 

This PR is to improve the upload logic to reduce the requests and related cost also (request is typical cost item).

I add some logs as test code to classify the issue: 
It send **3** requests for one file with size: 901.
[2025-03-18 06:28:38,160] INFO **CreateMultipartUploadRequest**: test_topic/27/00000000009398949865-GyuaUKJ3QEWC-ILUqyUt9A.rsm-manifest  cost: 16ms 
[2025-03-18 06:28:38,180] INFO **UploadPartRequest**: test_topic/27/00000000009398949865-GyuaUKJ3QEWC-ILUqyUt9A.rsm-manifest with size: 901, cost: 20ms
[2025-03-18 06:28:38,331] INFO **CompletedMultipartUpload**: test_topic/27/00000000009398949865-GyuaUKJ3QEWC-ILUqyUt9A.rsm-manifest  cost: 151ms  

After the changed code with debug log deployed:
It send only **1** request for the small file
[2025-03-18 07:06:03,179] INFO **PutObjectRequest**: test_topic/33/00000000000071382168-jsz4z8mTTAy9S-KwOEyMBg.rsm-manifest with size: 844, cost: 55ms 

### Part 2:  fix the upload's retry issue
The retry fail issue happen on upload's retry.  or you enable the checksum to calculate it. 
Example
java.lang.IllegalStateException: The request content has fewer bytes than the specified content-length: 1 bytes.
	at software.amazon.awssdk.core.internal.io.SdkLengthAwareInputStream.read(SdkLengthAwareInputStream.java:82)
	at software.amazon.awssdk.core.io.SdkFilterInputStream.read(SdkFilterInputStream.java:66)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:132)
	at software.amazon.awssdk.core.internal.io.SdkLengthAwareInputStream.read(SdkLengthAwareInputStream.java:75)
	at org.apache.http.entity.InputStreamEntity.writeTo(InputStreamEntity.java:140)
	at software.amazon.awssdk.http.apache.internal.RepeatableInputStreamRequestEntity.writeTo(RepeatableInputStreamRequestEntity.java:157)
	at org.apache.http.impl.execchain.RequestEntityProxy.writeTo(RequestEntityProxy.java:121)
	at org.apache.http.impl.DefaultBHttpClientConnection.sendRequestEntity(DefaultBHttpClientConnection.java:156)
	at org.apache.http.impl.conn.CPoolProxy.sendRequestEntity(CPoolProxy.java:152)
	at org.apache.http.protocol.HttpRequestExecutor.doSendRequest(HttpRequestExecutor.java:238)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:123)
	
Thanks for review. WDTY?
