### PR TITLE
MINOR: update readme on multipart size

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,8 @@ The plugin rate-limit is complementary to Tiered Storage Quotas.
 When uploading processed segments and indexes, multipart upload is used to put files on the storage back-end (e.g. AWS S3).
 
 > [!IMPORTANT]
-> To control the amount of upload part requests that are executed per segment, each storage back-end has a size configuration.
-> Consider increasing this value (e.g. 10x) to reduce the number of requests, and therefore its costs 
-> (default: minimum part size, e.g. `rsm.config.storage.s3.multipart.upload.part.size` for S3 is 5 MiB)
+> To control the amount of upload part requests that are executed per segment, each storage back-end has a PUT size configuration.
+> (default: minimum part size, e.g. `rsm.config.storage.s3.multipart.upload.part.size` for S3 is 25 MiB)
 
 Even though, multipart transactions are aborted when an exception happens while processing, 
 there's a chance that initiated transactions are not completed or aborted (e.g. broker process is killed) and incomplete part uploads hang without completing a transaction.


### PR DESCRIPTION
https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/commit/96c645d27d57c8f65e896a5203aafc1c1a6cf986 changed the default multipart upload size but didnt update the readme. I figure we can omit the recommendation to increase the value at this point