### PR TITLE
fix(build): Flaky ChunkCacheMetricsTest

### DIFF
--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCacheMetricsTest.java
@@ -114,39 +114,49 @@ class ChunkCacheMetricsTest {
 
         chunkCache.getChunk(OBJECT_KEY_PATH, segmentManifest, 0);
 
-        // Then the following metrics should be available
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-hits-total"))
-            .isEqualTo(1.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-misses-total"))
-            .isEqualTo(1.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-time-total"))
-            .asInstanceOf(DOUBLE)
-            .isGreaterThan(0);
-
-        // compute is considered as load success regardless if present or not
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-total"))
-            .isEqualTo(2.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-time-total"))
-            .isEqualTo(0.0);
-
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-total"))
-            .isEqualTo(0.0);
-
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-total"))
-            .isEqualTo(0.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-weight-total"))
-            .isEqualTo(0.0);
-
         final var threadPoolObjectName =
             new ObjectName("aiven.kafka.server.tieredstorage.thread-pool:type=chunk-cache-thread-pool-metrics");
+        // Then the following metrics should be available
+        await()
+            .atMost(Duration.ofSeconds(1)).untilAsserted(() -> {
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-hits-total"))
+                    .isEqualTo(1.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-misses-total"))
+                    .isEqualTo(1.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-time-total"))
+                    .asInstanceOf(DOUBLE)
+                    .isGreaterThan(0);
 
-        // The following assertions are relaxed, just to show that metrics are collected
-        assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "parallelism-total"))
-            .isEqualTo(4.0);
-        // approximation to completed tasks
-        assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "steal-task-count-total"))
-            .asInstanceOf(DOUBLE)
-            .isGreaterThanOrEqualTo(0.0);
+                // compute is considered as load success regardless if present or not
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-total"))
+                    .isEqualTo(2.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-time-total"))
+                    .isEqualTo(0.0);
+
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-total"))
+                    .isEqualTo(0.0);
+
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-total"))
+                    .isEqualTo(0.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-weight-total"))
+                    .isEqualTo(0.0);
+
+                // The following assertions are relaxed, just to show that metrics are collected
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "parallelism-total"))
+                    .isEqualTo(4.0);
+                // approximation to completed tasks
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "steal-task-count-total"))
+                    .asInstanceOf(DOUBLE)
+                    .isGreaterThanOrEqualTo(0.0);
+                // wait for thread-pool to drain queued tasks
+                // The following assertions are relaxed, just to show that metrics are collected
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "parallelism-total"))
+                    .isEqualTo(4.0);
+                // approximation to completed tasks
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "steal-task-count-total"))
+                    .asInstanceOf(DOUBLE)
+                    .isGreaterThanOrEqualTo(0.0);
+            });
         // wait for thread-pool to drain queued tasks
         await()
             .atMost(Duration.ofSeconds(5))

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCacheMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/manifest/MemorySegmentManifestCacheMetricsTest.java
@@ -101,40 +101,51 @@ class MemorySegmentManifestCacheMetricsTest {
 
         cache.get(OBJECT_KEY_PATH);
 
-        // Then the following metrics should be available
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-hits-total"))
-            .isEqualTo(1.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-misses-total"))
-            .isEqualTo(1.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-time-total"))
-            .asInstanceOf(DOUBLE)
-            .isGreaterThan(0);
-
-        // when using cache loader, load success seem to be only the missed loads (hits do not count)
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-total"))
-            .isEqualTo(1.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-time-total"))
-            .isEqualTo(0.0);
-
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-total"))
-            .isEqualTo(0.0);
-
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-total"))
-            .isEqualTo(0.0);
-        assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-weight-total"))
-            .isEqualTo(0.0);
-
         final var threadPoolObjectName =
             new ObjectName("aiven.kafka.server.tieredstorage.thread-pool:type="
                 + "segment-manifest-cache-thread-pool-metrics");
 
-        // The following assertions are relaxed, just to show that metrics are collected
-        assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "parallelism-total"))
-            .isEqualTo(4.0);
-        // approximation to completed tasks
-        assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "steal-task-count-total"))
-            .asInstanceOf(DOUBLE)
-            .isGreaterThanOrEqualTo(0.0);
+        await()
+            .atMost(Duration.ofSeconds(1))
+            .untilAsserted(() -> {
+                // Then the following metrics should be available
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-hits-total"))
+                    .isEqualTo(1.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-misses-total"))
+                    .isEqualTo(1.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-time-total"))
+                    .asInstanceOf(DOUBLE)
+                    .isGreaterThan(0);
+
+                // when using cache loader, load success seem to be only the missed loads (hits do not count)
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-success-total"))
+                    .isEqualTo(1.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-time-total"))
+                    .isEqualTo(0.0);
+
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-load-failure-total"))
+                    .isEqualTo(0.0);
+
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-total"))
+                    .isEqualTo(0.0);
+                assertThat(MBEAN_SERVER.getAttribute(objectName, "cache-eviction-weight-total"))
+                    .isEqualTo(0.0);
+
+                // The following assertions are relaxed, just to show that metrics are collected
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "parallelism-total"))
+                    .isEqualTo(4.0);
+                // approximation to completed tasks
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "steal-task-count-total"))
+                    .asInstanceOf(DOUBLE)
+                    .isGreaterThanOrEqualTo(0.0);
+                // The following assertions are relaxed, just to show that metrics are collected
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "parallelism-total"))
+                    .isEqualTo(4.0);
+                // approximation to completed tasks
+                assertThat(MBEAN_SERVER.getAttribute(threadPoolObjectName, "steal-task-count-total"))
+                    .asInstanceOf(DOUBLE)
+                    .isGreaterThanOrEqualTo(0.0);
+            });
         // wait for thread-pool to drain queued tasks
         await()
             .atMost(Duration.ofSeconds(5))


### PR DESCRIPTION
About this change - What it does
- Fixes flaky metrics tests. 

Resolves: #690
Why this way

Next logs indicates the cause of issue:
- added verbose logging in multiple places + thread producing logs
- simulated delay in metrics publish to make case reproducible


Method modified to reproduce: **io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter#recordLoadSuccess**
```
    @Override
    public void recordLoadSuccess(final long loadTime) {
        cacheLoadSuccessCount.increment();
        log.info("Incremented load success count: {}", cacheLoadSuccessCount.sum());
        try {
            log.info("Simulating delay for time recording.");
            Thread.sleep(1000);
        } catch (InterruptedException e) {
            throw new RuntimeException(e);
        }
        log.info("Before recording success time total");
        cacheLoadSuccessTimeTotal.add(loadTime);
        log.info("After recorded success time total");
    }
```
Logs from execution with threads where it happens:
```
[2025-06-08 19:20:19,413] [Test worker] INFO GetChunk 2 execution started (io.aiven.kafka.tieredstorage.fetch.cache.ChunkCacheMetricsTest:126)
[2025-06-08 19:20:19,414] [ForkJoinPool-3-worker-2] INFO Before calls statsCounter.recordHit(); (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:103)
[2025-06-08 19:20:19,414] [ForkJoinPool-3-worker-2] INFO After calls statsCounter.recordHit(); (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:105)
[2025-06-08 19:20:19,414] [ForkJoinPool-3-worker-2] INFO Incremented load success count: 2 (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:188)
[2025-06-08 19:20:19,415] [ForkJoinPool-3-worker-2] INFO Simulating delay for time recording. (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:190)
[2025-06-08 19:20:19,414] [Test worker] INFO getChunk execution completed. Returning the result (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:117)
[2025-06-08 19:20:19,415] [Test worker] INFO Validation the result second part after 2 run: chunkCache.getChunk(OBJECT_KEY_PATH, segmentManifest, 0); (io.aiven.kafka.tieredstorage.fetch.cache.ChunkCacheMetricsTest:128)


Expecting actual:
  0.0
to be greater than:
  0.0

```

Next lines of code:

```
        cacheLoadSuccessCount.increment();
        cacheLoadSuccessTimeTotal.add(loadTime);
```
get executed in separate thread independently from return from `chunkCache#getChunk` method
```
[2025-06-08 19:20:19,415] [ForkJoinPool-3-worker-2] INFO Simulating delay for time recording. (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:190) <= added artificial delay to make delay in metrics recording
[2025-06-08 19:20:19,414] [Test worker] INFO getChunk execution completed. Returning the result (io.aiven.kafka.tieredstorage.metrics.CaffeineStatsCounter:117)

// no logs here indicating that cacheLoadSuccessTimeTotal gets updated
```

the issue caused by next steps of asyncronous execution from getChunk method:
**io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache#getChunk**
```
                    }
                }, executor))
               // continue asynchronously after the main method returns value.
                .thenApplyAsync(t -> result.get())
                .get(getTimeout.toMillis(), TimeUnit.MILLISECONDS);
``