### PR TITLE
Remove Java 11 from pipeline

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -68,10 +68,10 @@ jobs:
       #- run: |
       #   make bootstrap
       #   make release
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build with Gradle

--- a/.github/workflows/main_push_and_pull_request_workflow.yml
+++ b/.github/workflows/main_push_and_pull_request_workflow.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [ 11, 17, 21 ]
+        java-version: [ 17, 21 ]
     name: Build on ${{ matrix.runs-on }} with jdk ${{ matrix.java-version }}
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +40,7 @@ jobs:
   e2e_test:
     strategy:
       matrix:
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         test: [ 'LocalSystem', 'S3', 'Gcs', 'Azure' ]
     name: E2E tests for ${{ matrix.test }}  with jdk ${{ matrix.java-version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
As we're starting depending on some broker internals which are built for min Java 17, remove Java 11 from the versions.
