### PR TITLE
Excluding JUnitPlatformLauncher from pitest configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ subprojects {
         outputFormats.addAll('XML', 'HTML')
         mutators.add('ALL')
         exportLineCoverage = true
+        addJUnitPlatformLauncher = false
         if (project.name in ['storage']) {
             failWhenNoMutations = false
         }


### PR DESCRIPTION
Since the dependency is already there, enabling it in pitest plugin breaks some Intellij features.

About this change - What it does

Resolves: #xxxxx
Why this way
