### PR TITLE
Adding AWS KMS dependency.

### DIFF
--- a/storage/s3/build.gradle
+++ b/storage/s3/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     }
     implementation ("software.amazon.awssdk:s3:$awsSdkVersion") {excludeFromAWSDeps(it)}
     runtimeOnly ("software.amazon.awssdk:sts:$awsSdkVersion") {excludeFromAWSDeps(it)}
+    // TODO: Needed for Iceberg. We need to figure out how to manage Iceberg-specific dependencies.
+    runtimeOnly ("software.amazon.awssdk:kms:$awsSdkVersion") {excludeFromAWSDeps(it)}
 
     implementation project(':commons')
 


### PR DESCRIPTION
Apache Iceberg 1.10.0 has hard dependency on KMS.

About this change - What it does

Resolves: #xxxxx
Why this way
