### PR TITLE
Upgrade AWS SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ subprojects {
 
         awaitilityVersion = "4.3.0"
 
-        awsSdkVersion = "2.32.30"
+        awsSdkVersion = "2.33.9"
 
         gcpSdkVersion = "2.54.0"
 


### PR DESCRIPTION
Upgrading AWS SDK to match version that Apache Iceberg uses

About this change - What it does

Resolves: #xxxxx
Why this way
