### PR TITLE
S3StorageConfig: reduce upperbound for s3.multipart.upload.part.size

### DIFF
--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -67,7 +67,7 @@ public class S3StorageConfig extends AbstractConfig {
         + "The higher the part size, the more memory is needed to buffer the part. "
         + "Valid values: between 5MiB and 2GiB";
     static final int S3_MULTIPART_UPLOAD_PART_SIZE_MIN = 5 * 1024 * 1024; // 5MiB
-    static final int S3_MULTIPART_UPLOAD_PART_SIZE_MAX = Integer.MAX_VALUE;
+    static final int S3_MULTIPART_UPLOAD_PART_SIZE_MAX = Integer.MAX_VALUE - 8;
     static final int S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT = 25 * 1024 * 1024; // 25MiB
 
     private static final String S3_API_CALL_TIMEOUT_CONFIG = "s3.api.call.timeout";


### PR DESCRIPTION
`s3.multipart.upload.part.size` currently has an upperbound of `Integer.MAX_VALUE` which may cause `OutOfMemoryError("Requested array size exceeds VM limit")` to be raised depending on the underlying JVM implementation. Even OpenJDK makes this assumption and sets a conservative upperbound for array sizes [[0]].

This change therefore sets the upperbound to `Integer.MAX_VALUE - 8` aligning it with OpenJDK.

[0]: https://github.com/openjdk/jdk/blob/e19035577724f40aca14ef7d5dad0906ce9e89ab/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java#L854