### PR TITLE
Remove Java 11 from release pipeline

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Java SDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Checkout code


### PR DESCRIPTION
Fixes release pipeline missing from #722 