### PR TITLE
Fix consumer infinite loop

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/IcebergRemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/IcebergRemoteStorageManager.java
@@ -303,7 +303,7 @@ public class IcebergRemoteStorageManager extends InternalRemoteStorageManager {
             remoteLogSegmentMetadata.topicIdPartition().topicPartition().partition());
         kafkaPart.put(RowSchema.Fields.OFFSET, parsedRecord.recordOffset());
         kafkaPart.put(RowSchema.Fields.TIMESTAMP, parsedRecord.recordTimestamp());
-        kafkaPart.put(RowSchema.Fields.BATCH_BYTE_OFFSET, offsetIndex.lookup(parsedRecord.recordOffset()).position);
+        kafkaPart.put(RowSchema.Fields.BATCH_BYTE_OFFSET, offsetIndex.lookup(batch.baseOffset()).position);
         kafkaPart.put(RowSchema.Fields.BATCH_BASE_OFFSET, batch.baseOffset());
         kafkaPart.put(RowSchema.Fields.BATCH_PARTITION_LEADER_EPOCH, batch.partitionLeaderEpoch());
         kafkaPart.put(RowSchema.Fields.BATCH_MAGIC, batch.magic());
@@ -396,8 +396,7 @@ public class IcebergRemoteStorageManager extends InternalRemoteStorageManager {
                     return Parquet.read(io.newInputFile(dataFileMetadata.location()))
                         .project(table.schema())
                         .createReaderFunc((s, mt) -> ParquetAvroValueReaders.buildReader(s, mt, recordSchema))
-                        .filter(Expressions.greaterThanOrEqual("kafka.batch_byte_offset",
-                            remoteLogSegmentMetadata.startOffset()))
+                        .filter(Expressions.greaterThanOrEqual("kafka.batch_byte_offset", startPosition))
                         .build();
                 }));
             return new LazySequenceInputStream(new BatchEnumeration(recordBatchGrouper, this.structureProvider, topic));

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/iceberg/RecordBatchGrouperTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/iceberg/RecordBatchGrouperTest.java
@@ -41,9 +41,9 @@ class RecordBatchGrouperTest {
 
     @Test
     void singleBatch() throws IOException {
-        final GenericData.Record record1 = recordWithBatchByteOffset(1);
-        final GenericData.Record record2 = recordWithBatchByteOffset(1);
-        final GenericData.Record record3 = recordWithBatchByteOffset(1);
+        final GenericData.Record record1 = recordWithBatchIdentity(100L, 1L, 0);
+        final GenericData.Record record2 = recordWithBatchIdentity(100L, 1L, 0);
+        final GenericData.Record record3 = recordWithBatchIdentity(100L, 1L, 0);
 
         final MultiFileReader reader = mock(MultiFileReader.class);
         when(reader.read()).thenReturn(record1, record2, record3, null);
@@ -56,10 +56,10 @@ class RecordBatchGrouperTest {
 
     @Test
     void multipleBatches() throws IOException {
-        final GenericData.Record record1 = recordWithBatchByteOffset(1);
-        final GenericData.Record record2 = recordWithBatchByteOffset(1);
-        final GenericData.Record record3 = recordWithBatchByteOffset(2);
-        final GenericData.Record record4 = recordWithBatchByteOffset(3);
+        final GenericData.Record record1 = recordWithBatchIdentity(100L, 1L, 0);
+        final GenericData.Record record2 = recordWithBatchIdentity(100L, 1L, 0);
+        final GenericData.Record record3 = recordWithBatchIdentity(150L, 1L, 1);
+        final GenericData.Record record4 = recordWithBatchIdentity(200L, 1L, 2);
 
         final MultiFileReader reader = mock(MultiFileReader.class);
         when(reader.read()).thenReturn(record1, record2, record3, record4, null);
@@ -72,15 +72,15 @@ class RecordBatchGrouperTest {
     }
 
     /**
-     * Tests that if a previous batch reoccurs, we still return everthing correctly.
+     * Tests that if a previous batch reoccurs, we still return everything correctly.
      * Not expected to happen for real.
      */
     @Test
     void returningToPreviousBatches() throws IOException {
-        final GenericData.Record record1 = recordWithBatchByteOffset(1);
-        final GenericData.Record record2 = recordWithBatchByteOffset(2);
-        final GenericData.Record record3 = recordWithBatchByteOffset(2);
-        final GenericData.Record record4 = recordWithBatchByteOffset(1);
+        final GenericData.Record record1 = recordWithBatchIdentity(100L, 1L, 0);
+        final GenericData.Record record2 = recordWithBatchIdentity(150L, 1L, 1);
+        final GenericData.Record record3 = recordWithBatchIdentity(150L, 1L, 1);
+        final GenericData.Record record4 = recordWithBatchIdentity(100L, 1L, 0);
 
         final MultiFileReader reader = mock(MultiFileReader.class);
         when(reader.read()).thenReturn(record1, record2, record3, record4, null);
@@ -92,9 +92,15 @@ class RecordBatchGrouperTest {
         assertThat(grouper.nextBatch()).isNull();
     }
 
-    private GenericData.Record recordWithBatchByteOffset(final int batchByteOffset) {
+    private GenericData.Record recordWithBatchIdentity(
+        final long baseOffset,
+        final long producerId,
+        final int baseSequence
+    ) {
         final GenericData.Record kafka = mock(GenericData.Record.class);
-        when(kafka.get(eq(RowSchema.Fields.BATCH_BYTE_OFFSET))).thenReturn(batchByteOffset);
+        when(kafka.get(eq(RowSchema.Fields.BATCH_BASE_OFFSET))).thenReturn(baseOffset);
+        when(kafka.get(eq(RowSchema.Fields.BATCH_PRODUCER_ID))).thenReturn(producerId);
+        when(kafka.get(eq(RowSchema.Fields.BATCH_BASE_SEQUENCE))).thenReturn(baseSequence);
         final GenericData.Record record = mock(GenericData.Record.class);
         when(record.get(eq(RowSchema.Fields.KAFKA))).thenReturn(kafka);
         return record;


### PR DESCRIPTION
Consumers got stuck fetching from Iceberg due to incorrect batch merging. Multiple batches with the same sparse offset index position were merged into giant batches, causing fetch size overflow and truncation.

Fixed by:
1. Using batch.baseOffset() instead of recordOffset() for position lookup
2. Grouping by BatchIdentity (offset+producerId+sequence) not byte offset
3. Updated tests to match new grouping logic

This ensures each batch is reconstructed independently, preventing inflation and consumer stalls.

Resolves: #762 
