### PR TITLE
Fix key prefix config name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ rsm.config.storage.backend.class=io.aiven.kafka.tieredstorage.storage.gcs.GcsSto
 rsm.config.storage.gcs.bucket.name=my-bucket
 rsm.config.storage.gcs.credentials.default=true
 # The prefix can be skipped:
-#rsm.config.storage.key.prefix: "some/prefix/"
+#rsm.config.key.prefix=some/prefix/
 
 # ----- Configure the fetch chunk cache -----
 


### PR DESCRIPTION
Updates `rsm.config.storage.key.prefix` to `rsm.config.key.prefix`. 

The key prefix config is on the `RemoteStorageManagerConfig` level so it's not prefixed with the storage prefix. If we use the example config in the README the key prefix isn't picked up and we write to the root path of the bucket. 
