### PR TITLE
#820: catch-OOM-retry fix for copyLogSegmentData (logzio prod-validation branch — focused PR to follow)

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/KafkaRemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/KafkaRemoteStorageManager.java
@@ -222,6 +222,10 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
             }
 
             return buildCustomMetadata(customMetadataBuilder);
+        } catch (final OutOfMemoryError oom) {
+            log.error("[logzio-rsm-trace] KafkaRemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={} — wrapping as RuntimeException so $RLMCopyTask retries on next cycle",
+                remoteLogSegmentMetadata, oom.getClass().getName(), oom.getMessage(), oom);
+            throw new RuntimeException("OOM during S3 upload; retryable on next $RLMCopyTask cycle", oom);
         } catch (final Error t) {
             log.error("[logzio-rsm-trace] KafkaRemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={}",
                 remoteLogSegmentMetadata, t.getClass().getName(), t.getMessage(), t);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/KafkaRemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/KafkaRemoteStorageManager.java
@@ -223,9 +223,14 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
 
             return buildCustomMetadata(customMetadataBuilder);
         } catch (final OutOfMemoryError oom) {
-            log.error("[logzio-rsm-trace] KafkaRemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={} — wrapping as RuntimeException so $RLMCopyTask retries on next cycle",
-                remoteLogSegmentMetadata, oom.getClass().getName(), oom.getMessage(), oom);
-            throw new RuntimeException("OOM during S3 upload; retryable on next $RLMCopyTask cycle", oom);
+            log.error("[logzio-rsm-trace] KafkaRemoteStorageManager.copyLogSegmentData OOM metadata={}",
+                remoteLogSegmentMetadata, oom);
+            try {
+                deleteSegmentObjects(remoteLogSegmentMetadata);
+            } catch (final Exception ex) {
+                log.warn("Removing orphan files failed after OOM", ex);
+            }
+            throw new RemoteStorageException("OOM during S3 upload; retryable", oom);
         } catch (final Error t) {
             log.error("[logzio-rsm-trace] KafkaRemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={}",
                 remoteLogSegmentMetadata, t.getClass().getName(), t.getMessage(), t);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/KafkaRemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/KafkaRemoteStorageManager.java
@@ -168,57 +168,65 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
         final LogSegmentData logSegmentData,
         final UploadMetricReporter uploadMetricReporter
     ) throws RemoteStorageException {
-        final var customMetadataBuilder =
-            new SegmentCustomMetadataBuilder(customMetadataFields, objectKeyFactory, remoteLogSegmentMetadata);
-
+        log.debug("[logzio-rsm-trace] Entry: KafkaRemoteStorageManager.copyLogSegmentData id={}",
+            remoteLogSegmentMetadata.remoteLogSegmentId().id());
         try {
-            final boolean requiresCompression = requiresCompression(logSegmentData);
+            final var customMetadataBuilder =
+                new SegmentCustomMetadataBuilder(customMetadataFields, objectKeyFactory, remoteLogSegmentMetadata);
 
-            final DataKeyAndAAD maybeEncryptionKey;
-            if (encryptionEnabled) {
-                maybeEncryptionKey = aesEncryptionProvider.createDataKeyAndAAD();
-            } else {
-                maybeEncryptionKey = null;
-            }
-
-            final ChunkIndex chunkIndex = uploadSegmentLog(
-                remoteLogSegmentMetadata,
-                logSegmentData,
-                requiresCompression,
-                maybeEncryptionKey,
-                customMetadataBuilder,
-                uploadMetricReporter
-            );
-
-            final SegmentIndexesV1 segmentIndexes = uploadIndexes(
-                remoteLogSegmentMetadata,
-                logSegmentData,
-                maybeEncryptionKey,
-                customMetadataBuilder,
-                uploadMetricReporter
-            );
-
-            uploadManifest(
-                remoteLogSegmentMetadata,
-                chunkIndex,
-                segmentIndexes,
-                requiresCompression,
-                maybeEncryptionKey,
-                customMetadataBuilder,
-                uploadMetricReporter
-            );
-        } catch (final Exception e) {
             try {
-                // best effort on removing orphan files
-                deleteSegmentObjects(remoteLogSegmentMetadata);
-            } catch (final Exception ex) {
-                // ignore all exceptions
-                log.warn("Removing orphan files failed", ex);
-            }
-            throw new RemoteStorageException(e);
-        }
+                final boolean requiresCompression = requiresCompression(logSegmentData);
 
-        return buildCustomMetadata(customMetadataBuilder);
+                final DataKeyAndAAD maybeEncryptionKey;
+                if (encryptionEnabled) {
+                    maybeEncryptionKey = aesEncryptionProvider.createDataKeyAndAAD();
+                } else {
+                    maybeEncryptionKey = null;
+                }
+
+                final ChunkIndex chunkIndex = uploadSegmentLog(
+                    remoteLogSegmentMetadata,
+                    logSegmentData,
+                    requiresCompression,
+                    maybeEncryptionKey,
+                    customMetadataBuilder,
+                    uploadMetricReporter
+                );
+
+                final SegmentIndexesV1 segmentIndexes = uploadIndexes(
+                    remoteLogSegmentMetadata,
+                    logSegmentData,
+                    maybeEncryptionKey,
+                    customMetadataBuilder,
+                    uploadMetricReporter
+                );
+
+                uploadManifest(
+                    remoteLogSegmentMetadata,
+                    chunkIndex,
+                    segmentIndexes,
+                    requiresCompression,
+                    maybeEncryptionKey,
+                    customMetadataBuilder,
+                    uploadMetricReporter
+                );
+            } catch (final Exception e) {
+                try {
+                    // best effort on removing orphan files
+                    deleteSegmentObjects(remoteLogSegmentMetadata);
+                } catch (final Exception ex) {
+                    // ignore all exceptions
+                    log.warn("Removing orphan files failed", ex);
+                }
+                throw new RemoteStorageException(e);
+            }
+
+            return buildCustomMetadata(customMetadataBuilder);
+        } catch (final Error t) {
+            log.error("[logzio-rsm-trace] KafkaRemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={}",
+                remoteLogSegmentMetadata, t.getClass().getName(), t.getMessage(), t);
+            throw t;
+        }
     }
 
     boolean requiresCompression(final LogSegmentData logSegmentData) {
@@ -248,6 +256,8 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
         final SegmentCustomMetadataBuilder customMetadataBuilder,
         final UploadMetricReporter uploadMetricReporter
     ) throws IOException, StorageBackendException {
+        log.debug("[logzio-rsm-trace] Entry: KafkaRemoteStorageManager.uploadSegmentLog id={}",
+            remoteLogSegmentMetadata.remoteLogSegmentId().id());
         final var objectKey = objectKeyFactory.key(remoteLogSegmentMetadata, ObjectKeyFactory.Suffix.LOG);
 
         try (final var logSegmentInputStream = Files.newInputStream(logSegmentData.logSegment())) {
@@ -267,6 +277,8 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
 
                 log.debug("Uploaded segment log for {}, size: {}", remoteLogSegmentMetadata, bytes);
             }
+            log.debug("[logzio-rsm-trace] Exit: KafkaRemoteStorageManager.uploadSegmentLog id={} outcome=completed",
+                remoteLogSegmentMetadata.remoteLogSegmentId().id());
             return transformFinisher.chunkIndex();
         }
     }
@@ -299,6 +311,8 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
         final SegmentCustomMetadataBuilder customMetadataBuilder,
         final UploadMetricReporter uploadMetricReporter
     ) throws IOException, RemoteStorageException, StorageBackendException {
+        log.debug("[logzio-rsm-trace] Entry: KafkaRemoteStorageManager.uploadIndexes id={}",
+            remoteLogSegmentMetadata.remoteLogSegmentId().id());
         final List<InputStream> indexes = new ArrayList<>(RemoteStorageManager.IndexType.values().length);
         final SegmentIndexesV1Builder segmentIndexBuilder = new SegmentIndexesV1Builder();
 
@@ -355,6 +369,8 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
                 log.debug("Uploaded indexes file for {}, size: {}", remoteLogSegmentMetadata, bytes);
             }
         }
+        log.debug("[logzio-rsm-trace] Exit: KafkaRemoteStorageManager.uploadIndexes id={} outcome=completed",
+            remoteLogSegmentMetadata.remoteLogSegmentId().id());
         return segmentIndexBuilder.build();
     }
 
@@ -418,6 +434,8 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
                         final SegmentCustomMetadataBuilder customMetadataBuilder,
                         final UploadMetricReporter uploadMetricReporter
     ) throws StorageBackendException, IOException {
+        log.debug("[logzio-rsm-trace] Entry: KafkaRemoteStorageManager.uploadManifest id={}",
+            remoteLogSegmentMetadata.remoteLogSegmentId().id());
         final SegmentEncryptionMetadataV1 maybeEncryptionMetadata;
         if (maybeEncryptionKey != null) {
             maybeEncryptionMetadata = new SegmentEncryptionMetadataV1(maybeEncryptionKey);
@@ -442,6 +460,8 @@ class KafkaRemoteStorageManager extends InternalRemoteStorageManager {
 
             log.debug("Uploaded segment manifest for {}, size: {}", remoteLogSegmentMetadata, bytes);
         }
+        log.debug("[logzio-rsm-trace] Exit: KafkaRemoteStorageManager.uploadManifest id={} outcome=completed",
+            remoteLogSegmentMetadata.remoteLogSegmentId().id());
     }
 
     @Override

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -99,28 +99,34 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
         log.info("Copying log segment data, metadata: {}", remoteLogSegmentMetadata);
 
-        final long startedMs = time.milliseconds();
+        try {
+            final long startedMs = time.milliseconds();
 
-        final UploadMetricReporter uploadMetricReporter = (suffix, bytes) -> {
-            metrics.recordObjectUpload(
+            final UploadMetricReporter uploadMetricReporter = (suffix, bytes) -> {
+                metrics.recordObjectUpload(
+                    remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
+                    suffix, bytes
+                );
+            };
+            final var customMetadata = switch (segmentFormat) {
+                case KAFKA ->
+                    kafkaRsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData, uploadMetricReporter);
+                case ICEBERG ->
+                    icebergRsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData, uploadMetricReporter);
+            };
+
+            metrics.recordSegmentCopyTime(
                 remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
-                suffix, bytes
-            );
-        };
-        final var customMetadata = switch (segmentFormat) {
-            case KAFKA ->
-                kafkaRsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData, uploadMetricReporter);
-            case ICEBERG ->
-                icebergRsm.copyLogSegmentData(remoteLogSegmentMetadata, logSegmentData, uploadMetricReporter);
-        };
+                startedMs, time.milliseconds());
 
-        metrics.recordSegmentCopyTime(
-            remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
-            startedMs, time.milliseconds());
+            log.info("Copying log segment data completed successfully, metadata: {}", remoteLogSegmentMetadata);
 
-        log.info("Copying log segment data completed successfully, metadata: {}", remoteLogSegmentMetadata);
-
-        return customMetadata;
+            return customMetadata;
+        } catch (final Error t) {
+            log.error("[logzio-rsm-trace] RemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={}",
+                remoteLogSegmentMetadata, t.getClass().getName(), t.getMessage(), t);
+            throw t;
+        }
     }
 
     @Override

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -122,6 +122,10 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
             log.info("Copying log segment data completed successfully, metadata: {}", remoteLogSegmentMetadata);
 
             return customMetadata;
+        } catch (final OutOfMemoryError oom) {
+            log.error("[logzio-rsm-trace] RemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={} — wrapping as RuntimeException so $RLMCopyTask retries on next cycle",
+                remoteLogSegmentMetadata, oom.getClass().getName(), oom.getMessage(), oom);
+            throw new RuntimeException("OOM during S3 upload; retryable on next $RLMCopyTask cycle", oom);
         } catch (final Error t) {
             log.error("[logzio-rsm-trace] RemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={}",
                 remoteLogSegmentMetadata, t.getClass().getName(), t.getMessage(), t);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -123,9 +123,9 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
 
             return customMetadata;
         } catch (final OutOfMemoryError oom) {
-            log.error("[logzio-rsm-trace] RemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={} — wrapping as RuntimeException so $RLMCopyTask retries on next cycle",
-                remoteLogSegmentMetadata, oom.getClass().getName(), oom.getMessage(), oom);
-            throw new RuntimeException("OOM during S3 upload; retryable on next $RLMCopyTask cycle", oom);
+            log.error("[logzio-rsm-trace] RemoteStorageManager.copyLogSegmentData OOM metadata={}",
+                remoteLogSegmentMetadata, oom);
+            throw new RemoteStorageException("OOM during S3 upload; retryable", oom);
         } catch (final Error t) {
             log.error("[logzio-rsm-trace] RemoteStorageManager.copyLogSegmentData ABORTED ABNORMALLY metadata={} cause={} message={}",
                 remoteLogSegmentMetadata, t.getClass().getName(), t.getMessage(), t);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.1.1
+version=1.1.1-logzio-trace
 org.gradle.jvmargs=-Xmx4096M
 sonatypeUsername=<fill>
 sonatypePassword=<fill>

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/MetricCollector.java
@@ -112,150 +112,13 @@ import static software.amazon.awssdk.core.internal.metrics.SdkErrorType.THROTTLI
 
 public class MetricCollector implements MetricPublisher {
     private static final Logger log = LoggerFactory.getLogger(MetricCollector.class);
-
-    private final org.apache.kafka.common.metrics.Metrics metrics;
-
-    private final Map<String, Sensor> requestMetrics = new HashMap<>();
-    private final Map<String, Sensor> latencyMetrics = new HashMap<>();
-    private final Map<String, Sensor> errorMetrics = new HashMap<>();
+    private static final SharedMetrics SHARED = new SharedMetrics();
 
     public MetricCollector() {
-        final MetricsReporter reporter = new JmxReporter();
-
-        metrics = new org.apache.kafka.common.metrics.Metrics(
-            new MetricConfig(), List.of(reporter), Time.SYSTEM,
-            new KafkaMetricsContext(METRIC_CONTEXT)
-        );
-        final Sensor getObjectRequestsSensor = createRequestsSensor(
-            GET_OBJECT_REQUESTS,
-            GET_OBJECT_REQUESTS_RATE_METRIC_NAME,
-            GET_OBJECT_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("GetObject", getObjectRequestsSensor);
-        final Sensor getObjectTimeSensor = createLatencySensor(
-            GET_OBJECT_TIME,
-            GET_OBJECT_TIME_AVG_METRIC_NAME,
-            GET_OBJECT_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("GetObject", getObjectTimeSensor);
-        final Sensor uploadPartRequestsSensor = createRequestsSensor(
-            UPLOAD_PART_REQUESTS,
-            UPLOAD_PART_REQUESTS_RATE_METRIC_NAME,
-            UPLOAD_PART_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("UploadPart", uploadPartRequestsSensor);
-        final Sensor uploadPartTimeSensor = createLatencySensor(
-            UPLOAD_PART_TIME,
-            UPLOAD_PART_TIME_AVG_METRIC_NAME,
-            UPLOAD_PART_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("UploadPart", uploadPartTimeSensor);
-        final Sensor createMpuRequestsSensor = createRequestsSensor(
-            CREATE_MULTIPART_UPLOAD_REQUESTS,
-            CREATE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
-            CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("CreateMultipartUpload", createMpuRequestsSensor);
-        final Sensor createMpuTimeSensor = createLatencySensor(
-            CREATE_MULTIPART_UPLOAD_TIME,
-            CREATE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
-            CREATE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("CreateMultipartUpload", createMpuTimeSensor);
-        final Sensor completeMpuRequestsSensor = createRequestsSensor(
-            COMPLETE_MULTIPART_UPLOAD_REQUESTS,
-            COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
-            COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("CompleteMultipartUpload", completeMpuRequestsSensor);
-        final Sensor completeMpuTimeSensor = createLatencySensor(
-            COMPLETE_MULTIPART_UPLOAD_TIME,
-            COMPLETE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
-            COMPLETE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("CompleteMultipartUpload", completeMpuTimeSensor);
-        final Sensor putObjectRequestsSensor = createRequestsSensor(
-            PUT_OBJECT_REQUESTS,
-            PUT_OBJECT_REQUESTS_RATE_METRIC_NAME,
-            PUT_OBJECT_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("PutObject", putObjectRequestsSensor);
-        final Sensor putObjectTimeSensor = createLatencySensor(
-            PUT_OBJECT_TIME,
-            PUT_OBJECT_TIME_AVG_METRIC_NAME,
-            PUT_OBJECT_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("PutObject", putObjectTimeSensor);
-        final Sensor deleteObjectRequestsSensor = createRequestsSensor(
-            DELETE_OBJECT_REQUESTS,
-            DELETE_OBJECT_REQUESTS_RATE_METRIC_NAME,
-            DELETE_OBJECT_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("DeleteObject", deleteObjectRequestsSensor);
-        final Sensor deleteObjectTimeSensor = createLatencySensor(
-            DELETE_OBJECT_TIME,
-            DELETE_OBJECT_TIME_AVG_METRIC_NAME,
-            DELETE_OBJECT_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("DeleteObject", deleteObjectTimeSensor);
-        final Sensor deleteObjectsRequestsSensor = createRequestsSensor(
-            DELETE_OBJECTS_REQUESTS,
-            DELETE_OBJECTS_REQUESTS_RATE_METRIC_NAME,
-            DELETE_OBJECTS_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("DeleteObjects", deleteObjectsRequestsSensor);
-        final Sensor deleteObjectsTimeSensor = createLatencySensor(
-            DELETE_OBJECTS_TIME,
-            DELETE_OBJECTS_TIME_AVG_METRIC_NAME,
-            DELETE_OBJECTS_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("DeleteObjects", deleteObjectsTimeSensor);
-        final Sensor abortMpuRequestsSensor = createRequestsSensor(
-            ABORT_MULTIPART_UPLOAD_REQUESTS,
-            ABORT_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME,
-            ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
-        );
-        requestMetrics.put("AbortMultipartUpload", abortMpuRequestsSensor);
-        final Sensor abortMpuTimeSensor = createLatencySensor(
-            ABORT_MULTIPART_UPLOAD_TIME,
-            ABORT_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME,
-            ABORT_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
-        );
-        latencyMetrics.put("AbortMultipartUpload", abortMpuTimeSensor);
-
-        final Sensor throttlingErrorsSensor = createRequestsSensor(
-            THROTTLING_ERRORS,
-            THROTTLING_ERRORS_RATE_METRIC_NAME,
-            THROTTLING_ERRORS_TOTAL_METRIC_NAME
-        );
-        errorMetrics.put(THROTTLING.toString(), throttlingErrorsSensor);
-        final Sensor serverErrorsSensor = createRequestsSensor(
-            SERVER_ERRORS,
-            SERVER_ERRORS_RATE_METRIC_NAME,
-            SERVER_ERRORS_TOTAL_METRIC_NAME
-        );
-        errorMetrics.put(SERVER_ERROR.toString(), serverErrorsSensor);
-        final Sensor configuredTimeoutErrorsSensor = createRequestsSensor(
-            CONFIGURED_TIMEOUT_ERRORS,
-            CONFIGURED_TIMEOUT_ERRORS_RATE_METRIC_NAME,
-            CONFIGURED_TIMEOUT_ERRORS_TOTAL_METRIC_NAME
-        );
-        errorMetrics.put(CONFIGURED_TIMEOUT.toString(), configuredTimeoutErrorsSensor);
-        final Sensor ioErrorsSensor = createRequestsSensor(
-            IO_ERRORS,
-            IO_ERRORS_RATE_METRIC_NAME,
-            IO_ERRORS_TOTAL_METRIC_NAME
-        );
-        errorMetrics.put(IO.toString(), ioErrorsSensor);
-        final Sensor otherErrorsSensor = createRequestsSensor(
-            OTHER_ERRORS,
-            OTHER_ERRORS_RATE_METRIC_NAME,
-            OTHER_ERRORS_TOTAL_METRIC_NAME
-        );
-        errorMetrics.put(OTHER.toString(), otherErrorsSensor);
     }
 
-    private Sensor createRequestsSensor(
+    private static Sensor createRequestsSensor(
+        final org.apache.kafka.common.metrics.Metrics metrics,
         final String name,
         final MetricNameTemplate rateMetricName,
         final MetricNameTemplate totalMetricName
@@ -266,7 +129,8 @@ public class MetricCollector implements MetricPublisher {
         return sensor;
     }
 
-    private Sensor createLatencySensor(
+    private static Sensor createLatencySensor(
+        final org.apache.kafka.common.metrics.Metrics metrics,
         final String name,
         final MetricNameTemplate avgMetricName,
         final MetricNameTemplate maxMetricName
@@ -283,14 +147,14 @@ public class MetricCollector implements MetricPublisher {
         // metrics are reported per request, so 1 value can be assumed.
         if (metricValues.size() == 1) {
             final var metricValue = metricValues.get(0);
-            final var requests = requestMetrics.get(metricValue);
+            final var requests = SHARED.requestMetrics.get(metricValue);
             if (requests != null) {
                 requests.record();
             }
 
             final var durations = metricCollection.metricValues(CoreMetric.API_CALL_DURATION);
             if (durations.size() == 1) {
-                final var latency = latencyMetrics.get(metricValue);
+                final var latency = SHARED.latencyMetrics.get(metricValue);
                 if (latency != null) {
                     latency.record(durations.get(0).toMillis());
                 }
@@ -312,7 +176,7 @@ public class MetricCollector implements MetricPublisher {
             .collect(Collectors.toList());
 
         for (final String errorValue : errorValues) {
-            final var sensor = errorMetrics.get(errorValue);
+            final var sensor = SHARED.errorMetrics.get(errorValue);
             if (sensor != null) {
                 sensor.record();
             }
@@ -321,6 +185,94 @@ public class MetricCollector implements MetricPublisher {
 
     @Override
     public void close() {
-        metrics.close();
+        // shared metrics should outlive individual MetricCollector instances
+    }
+
+    private static final class SharedMetrics {
+        private final org.apache.kafka.common.metrics.Metrics metrics;
+        private final Map<String, Sensor> requestMetrics = new HashMap<>();
+        private final Map<String, Sensor> latencyMetrics = new HashMap<>();
+        private final Map<String, Sensor> errorMetrics = new HashMap<>();
+
+        private SharedMetrics() {
+            final MetricsReporter reporter = new JmxReporter();
+
+            metrics = new org.apache.kafka.common.metrics.Metrics(
+                new MetricConfig(), List.of(reporter), Time.SYSTEM,
+                new KafkaMetricsContext(METRIC_CONTEXT)
+            );
+
+            requestMetrics.put("GetObject", createRequestsSensor(
+                metrics, GET_OBJECT_REQUESTS, GET_OBJECT_REQUESTS_RATE_METRIC_NAME, GET_OBJECT_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("GetObject", createLatencySensor(
+                metrics, GET_OBJECT_TIME, GET_OBJECT_TIME_AVG_METRIC_NAME, GET_OBJECT_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("UploadPart", createRequestsSensor(
+                metrics, UPLOAD_PART_REQUESTS, UPLOAD_PART_REQUESTS_RATE_METRIC_NAME, UPLOAD_PART_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("UploadPart", createLatencySensor(
+                metrics, UPLOAD_PART_TIME, UPLOAD_PART_TIME_AVG_METRIC_NAME, UPLOAD_PART_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("CreateMultipartUpload", createRequestsSensor(
+                metrics, CREATE_MULTIPART_UPLOAD_REQUESTS,
+                CREATE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME, CREATE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("CreateMultipartUpload", createLatencySensor(
+                metrics, CREATE_MULTIPART_UPLOAD_TIME,
+                CREATE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME, CREATE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("CompleteMultipartUpload", createRequestsSensor(
+                metrics, COMPLETE_MULTIPART_UPLOAD_REQUESTS,
+                COMPLETE_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME, COMPLETE_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("CompleteMultipartUpload", createLatencySensor(
+                metrics, COMPLETE_MULTIPART_UPLOAD_TIME,
+                COMPLETE_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME, COMPLETE_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("PutObject", createRequestsSensor(
+                metrics, PUT_OBJECT_REQUESTS, PUT_OBJECT_REQUESTS_RATE_METRIC_NAME, PUT_OBJECT_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("PutObject", createLatencySensor(
+                metrics, PUT_OBJECT_TIME, PUT_OBJECT_TIME_AVG_METRIC_NAME, PUT_OBJECT_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("DeleteObject", createRequestsSensor(
+                metrics, DELETE_OBJECT_REQUESTS, DELETE_OBJECT_REQUESTS_RATE_METRIC_NAME, DELETE_OBJECT_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("DeleteObject", createLatencySensor(
+                metrics, DELETE_OBJECT_TIME, DELETE_OBJECT_TIME_AVG_METRIC_NAME, DELETE_OBJECT_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("DeleteObjects", createRequestsSensor(
+                metrics, DELETE_OBJECTS_REQUESTS, DELETE_OBJECTS_REQUESTS_RATE_METRIC_NAME, DELETE_OBJECTS_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("DeleteObjects", createLatencySensor(
+                metrics, DELETE_OBJECTS_TIME, DELETE_OBJECTS_TIME_AVG_METRIC_NAME, DELETE_OBJECTS_TIME_MAX_METRIC_NAME
+            ));
+            requestMetrics.put("AbortMultipartUpload", createRequestsSensor(
+                metrics, ABORT_MULTIPART_UPLOAD_REQUESTS,
+                ABORT_MULTIPART_UPLOAD_REQUESTS_RATE_METRIC_NAME, ABORT_MULTIPART_UPLOAD_REQUESTS_TOTAL_METRIC_NAME
+            ));
+            latencyMetrics.put("AbortMultipartUpload", createLatencySensor(
+                metrics, ABORT_MULTIPART_UPLOAD_TIME,
+                ABORT_MULTIPART_UPLOAD_TIME_AVG_METRIC_NAME, ABORT_MULTIPART_UPLOAD_TIME_MAX_METRIC_NAME
+            ));
+
+            errorMetrics.put(THROTTLING.toString(), createRequestsSensor(
+                metrics, THROTTLING_ERRORS, THROTTLING_ERRORS_RATE_METRIC_NAME, THROTTLING_ERRORS_TOTAL_METRIC_NAME
+            ));
+            errorMetrics.put(SERVER_ERROR.toString(), createRequestsSensor(
+                metrics, SERVER_ERRORS, SERVER_ERRORS_RATE_METRIC_NAME, SERVER_ERRORS_TOTAL_METRIC_NAME
+            ));
+            errorMetrics.put(CONFIGURED_TIMEOUT.toString(), createRequestsSensor(
+                metrics, CONFIGURED_TIMEOUT_ERRORS,
+                CONFIGURED_TIMEOUT_ERRORS_RATE_METRIC_NAME, CONFIGURED_TIMEOUT_ERRORS_TOTAL_METRIC_NAME
+            ));
+            errorMetrics.put(IO.toString(), createRequestsSensor(
+                metrics, IO_ERRORS, IO_ERRORS_RATE_METRIC_NAME, IO_ERRORS_TOTAL_METRIC_NAME
+            ));
+            errorMetrics.put(OTHER.toString(), createRequestsSensor(
+                metrics, OTHER_ERRORS, OTHER_ERRORS_RATE_METRIC_NAME, OTHER_ERRORS_TOTAL_METRIC_NAME
+            ));
+        }
     }
 }

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
@@ -153,19 +153,12 @@ public class S3UploadOutputStream extends OutputStream {
         this.client = client;
         this.partSize = partSize;
         // FAULT INJECTION (staging-only): JIT eliminates this branch in prod.
-        // Two trigger modes — boolean one-shot for quick smoke tests, topic-substring
-        // sticky for end-to-end bloat reproduction on a dedicated test topic.
-        // Both throw at the same site where ByteBuffer.allocate(partSize) would naturally
-        // fail under heap pressure — same stack, same outer catch(Error t) chain.
-        if (FAULT_INJECTION_ENABLED) {
-            if (simulateOomOnNextConstruction) {
-                simulateOomOnNextConstruction = false;        // one-shot reset
-                throw new OutOfMemoryError("Java heap space");
-            }
-            final String substring = simulateOomForTopicSubstring;   // volatile-read once
-            if (!substring.isEmpty() && key.value().contains(substring)) {
-                throw new OutOfMemoryError("Java heap space");       // sticky until flipped off
-            }
+        // Boolean one-shot stays at the constructor for the quick-smoke-test semantics it had
+        // before the lazy-cache fix. The topic-substring check moved to growBufferTo() to ride
+        // along with the new lazy-allocate site — proves the allocation moved correctly.
+        if (FAULT_INJECTION_ENABLED && simulateOomOnNextConstruction) {
+            simulateOomOnNextConstruction = false;        // one-shot reset
+            throw new OutOfMemoryError("Java heap space");
         }
         // Aiven #820 lazy-cache fix: partBuffer is lazy, grown on demand inside write().
         // Constructor no longer allocates `partSize` (was the eager OOM site at the old line 86).
@@ -183,6 +176,17 @@ public class S3UploadOutputStream extends OutputStream {
      */
     private void growBufferTo(final int targetCapacity) {
         final int wanted = Math.min(partSize, Math.max(INITIAL_BUFFER_SIZE, targetCapacity));
+        // FAULT INJECTION (staging-only): JIT eliminates this branch in prod.
+        // Topic-substring check at the NEW lazy-allocate site (moved here from the constructor
+        // by Experiment 3.5 to validate the allocation actually moved out of <init>).
+        // When flag set, throws OOM right before the real ByteBuffer.allocate below — same
+        // outer catch(Error t) chain still fires ABORTED ABNORMALLY in copyLogSegmentData.
+        if (FAULT_INJECTION_ENABLED) {
+            final String substring = simulateOomForTopicSubstring;   // volatile-read once
+            if (!substring.isEmpty() && key.value().contains(substring)) {
+                throw new OutOfMemoryError("Java heap space");
+            }
+        }
         if (partBuffer == null) {
             partBuffer = ByteBuffer.allocate(wanted);
             return;

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
@@ -19,10 +19,13 @@ package io.aiven.kafka.tieredstorage.storage.s3;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
 
 import io.aiven.kafka.tieredstorage.storage.ObjectKey;
 
@@ -52,6 +55,48 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 public class S3UploadOutputStream extends OutputStream {
 
     private static final Logger log = LoggerFactory.getLogger(S3UploadOutputStream.class);
+
+    // FAULT INJECTION — staging-only Aiven #820 reproduction trigger.
+    // Gated by -Dio.aiven.faultinjection.enabled=true; in prod (system property absent)
+    // this is `static final false` and JIT eliminates the dead branch in the constructor.
+    private static final boolean FAULT_INJECTION_ENABLED =
+        Boolean.parseBoolean(System.getProperty("io.aiven.faultinjection.enabled", "false"));
+
+    // Operator-controlled one-shot flag (auto-resets after firing once).
+    // Toggle via JMX MBean io.aiven.kafka.tieredstorage:type=FaultInjection,name=S3UploadOom
+    private static volatile boolean simulateOomOnNextConstruction = false;
+
+    static {
+        if (FAULT_INJECTION_ENABLED) {
+            try {
+                final ObjectName name = new ObjectName(
+                    "io.aiven.kafka.tieredstorage:type=FaultInjection,name=S3UploadOom");
+                ManagementFactory.getPlatformMBeanServer().registerMBean(
+                    new StandardMBean(new FaultInjectionImpl(), FaultInjectionMBean.class),
+                    name);
+                log.info("[logzio-rsm-trace] FAULT INJECTION MBean registered (staging-only)");
+            } catch (final Exception e) {
+                log.warn("[logzio-rsm-trace] Could not register fault injection MBean", e);
+            }
+        }
+    }
+
+    public interface FaultInjectionMBean {
+        void setSimulateOomOnNextConstruction(boolean enabled);
+        boolean getSimulateOomOnNextConstruction();
+    }
+
+    static class FaultInjectionImpl implements FaultInjectionMBean {
+        @Override
+        public void setSimulateOomOnNextConstruction(final boolean v) {
+            simulateOomOnNextConstruction = v;
+        }
+
+        @Override
+        public boolean getSimulateOomOnNextConstruction() {
+            return simulateOomOnNextConstruction;
+        }
+    }
 
     private final S3Client client;
     private final ByteBuffer partBuffer;
@@ -83,6 +128,13 @@ public class S3UploadOutputStream extends OutputStream {
         this.storageClass = storageClass;
         this.client = client;
         this.partSize = partSize;
+        // FAULT INJECTION (staging-only): JIT eliminates this branch in prod.
+        // When flipped via JMX, throws OOM at the same site where ByteBuffer.allocate
+        // would naturally fail under heap pressure — same stack, same catch(Error t) chain.
+        if (FAULT_INJECTION_ENABLED && simulateOomOnNextConstruction) {
+            simulateOomOnNextConstruction = false;            // one-shot reset
+            throw new OutOfMemoryError("Java heap space");    // verbatim same msg as natural OOM
+        }
         this.partBuffer = ByteBuffer.allocate(partSize);
     }
 

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
@@ -66,6 +66,12 @@ public class S3UploadOutputStream extends OutputStream {
     // Toggle via JMX MBean io.aiven.kafka.tieredstorage:type=FaultInjection,name=S3UploadOom
     private static volatile boolean simulateOomOnNextConstruction = false;
 
+    // Operator-controlled sticky topic-scoped flag. When non-empty, every S3UploadOutputStream
+    // construction whose key.value() contains this substring throws OOM. Stays in effect until
+    // operator writes empty string (or null, which is coerced to ""). Designed for end-to-end
+    // bloat-reproduction on a dedicated test topic without affecting other partitions.
+    private static volatile String simulateOomForTopicSubstring = "";
+
     static {
         if (FAULT_INJECTION_ENABLED) {
             try {
@@ -84,6 +90,8 @@ public class S3UploadOutputStream extends OutputStream {
     public interface FaultInjectionMBean {
         void setSimulateOomOnNextConstruction(boolean enabled);
         boolean getSimulateOomOnNextConstruction();
+        void setSimulateOomForTopicSubstring(String substring);
+        String getSimulateOomForTopicSubstring();
     }
 
     static class FaultInjectionImpl implements FaultInjectionMBean {
@@ -96,10 +104,26 @@ public class S3UploadOutputStream extends OutputStream {
         public boolean getSimulateOomOnNextConstruction() {
             return simulateOomOnNextConstruction;
         }
+
+        @Override
+        public void setSimulateOomForTopicSubstring(final String substring) {
+            simulateOomForTopicSubstring = substring == null ? "" : substring;
+        }
+
+        @Override
+        public String getSimulateOomForTopicSubstring() {
+            return simulateOomForTopicSubstring;
+        }
     }
 
+    // Aiven #820 lazy-cache fix — see docs/kafka/tiered_storage/aiven-820-lazy-cache-fix-plan.md.
+    // Initial buffer size pre-sized from worst-case small-file uploads
+    // (segment.bytes=100M ⇒ indexes ≈ 300 KiB, manifest ≈ 3 KiB); 1 MiB covers both in a single
+    // allocation with no grow. Segment-log uploads grow on demand up to `partSize`.
+    private static final int INITIAL_BUFFER_SIZE = 1 * 1024 * 1024;
+
     private final S3Client client;
-    private final ByteBuffer partBuffer;
+    private ByteBuffer partBuffer;       // lazy, grow-on-demand up to partSize (Aiven #820 fix)
     private final String bucketName;
     private final ObjectKey key;
     private final StorageClass storageClass;
@@ -129,13 +153,48 @@ public class S3UploadOutputStream extends OutputStream {
         this.client = client;
         this.partSize = partSize;
         // FAULT INJECTION (staging-only): JIT eliminates this branch in prod.
-        // When flipped via JMX, throws OOM at the same site where ByteBuffer.allocate
-        // would naturally fail under heap pressure — same stack, same catch(Error t) chain.
-        if (FAULT_INJECTION_ENABLED && simulateOomOnNextConstruction) {
-            simulateOomOnNextConstruction = false;            // one-shot reset
-            throw new OutOfMemoryError("Java heap space");    // verbatim same msg as natural OOM
+        // Two trigger modes — boolean one-shot for quick smoke tests, topic-substring
+        // sticky for end-to-end bloat reproduction on a dedicated test topic.
+        // Both throw at the same site where ByteBuffer.allocate(partSize) would naturally
+        // fail under heap pressure — same stack, same outer catch(Error t) chain.
+        if (FAULT_INJECTION_ENABLED) {
+            if (simulateOomOnNextConstruction) {
+                simulateOomOnNextConstruction = false;        // one-shot reset
+                throw new OutOfMemoryError("Java heap space");
+            }
+            final String substring = simulateOomForTopicSubstring;   // volatile-read once
+            if (!substring.isEmpty() && key.value().contains(substring)) {
+                throw new OutOfMemoryError("Java heap space");       // sticky until flipped off
+            }
         }
-        this.partBuffer = ByteBuffer.allocate(partSize);
+        // Aiven #820 lazy-cache fix: partBuffer is lazy, grown on demand inside write().
+        // Constructor no longer allocates `partSize` (was the eager OOM site at the old line 86).
+    }
+
+    /**
+     * Grow {@link #partBuffer} so its capacity is at least {@code targetCapacity} bytes
+     * (clamped to {@link #partSize}). Lazy-init on first call. Preserves any previously
+     * written bytes (position is carried over to the new buffer). Old buffer is dropped for GC.
+     *
+     * <p>Aiven #820 lazy-cache fix: small-file uploads (indexes, manifest) typically cap at the
+     * initial 1 MiB allocation without ever growing; segment-log uploads grow by doubling up to
+     * {@code partSize}. Peak per-instance heap usage matches the previous eager allocation only
+     * for full multipart uploads; small-file uploads see ~96 % heap savings.
+     */
+    private void growBufferTo(final int targetCapacity) {
+        final int wanted = Math.min(partSize, Math.max(INITIAL_BUFFER_SIZE, targetCapacity));
+        if (partBuffer == null) {
+            partBuffer = ByteBuffer.allocate(wanted);
+            return;
+        }
+        if (partBuffer.capacity() >= wanted) {
+            return;
+        }
+        final int newCap = Math.min(partSize, Math.max(wanted, partBuffer.capacity() * 2));
+        final ByteBuffer larger = ByteBuffer.allocate(newCap);
+        partBuffer.flip();          // limit=position, position=0 (prepare for read)
+        larger.put(partBuffer);     // copies bytes; larger.position advances; partBuffer dropped after
+        partBuffer = larger;
     }
 
     @Override
@@ -155,6 +214,13 @@ public class S3UploadOutputStream extends OutputStream {
             try {
                 final ByteBuffer inputBuffer = ByteBuffer.wrap(b, off, len);
                 while (inputBuffer.hasRemaining()) {
+                    // Aiven #820 lazy-cache fix: lazy-init / grow-on-demand. Each iteration
+                    // ensures at least 1 byte of space; grow up to `partSize` cap as needed.
+                    if (partBuffer == null || (!partBuffer.hasRemaining() && partBuffer.capacity() < partSize)) {
+                        final int current = partBuffer == null ? 0 : partBuffer.position();
+                        growBufferTo(current + inputBuffer.remaining());
+                    }
+
                     // copy batch to part buffer
                     final int inputLimit = inputBuffer.limit();
                     final int toCopy = Math.min(partBuffer.remaining(), inputBuffer.remaining());
@@ -166,7 +232,8 @@ public class S3UploadOutputStream extends OutputStream {
                     inputBuffer.limit(inputLimit);
                     inputBuffer.position(positionAfterCopying);
 
-                    if (!partBuffer.hasRemaining()) {
+                    // Flush as a multipart part only when buffer reached `partSize` AND is full.
+                    if (!partBuffer.hasRemaining() && partBuffer.capacity() == partSize) {
                         if (uploadId == null){
                             uploadId = createMultipartUploadRequest();
                             // this is not expected (another exception should be thrown by S3) but adding for completeness
@@ -177,6 +244,7 @@ public class S3UploadOutputStream extends OutputStream {
                         partBuffer.position(0);
                         partBuffer.limit(partSize);
                         flushBuffer(partBuffer.slice(), partSize, true);
+                        partBuffer.clear();    // reset position=0, limit=capacity for the next part
                     }
                 }
             } catch (final RuntimeException e) {
@@ -216,7 +284,8 @@ public class S3UploadOutputStream extends OutputStream {
         try {
             if (!isClosed()) {
                 closed = true;
-                final int lastPosition = partBuffer.position();
+                // Aiven #820 lazy-cache fix: partBuffer may be null if write() was never called.
+                final int lastPosition = (partBuffer == null) ? 0 : partBuffer.position();
                 if (lastPosition > 0) {
                     try {
                         partBuffer.position(0);

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3UploadOutputStream.java
@@ -93,55 +93,65 @@ public class S3UploadOutputStream extends OutputStream {
 
     @Override
     public void write(final byte[] b, final int off, final int len) throws IOException {
-        if (isClosed()) {
-            throw new IllegalStateException("Already closed");
-        }
-        if (b.length == 0) {
-            return;
-        }
         try {
-            final ByteBuffer inputBuffer = ByteBuffer.wrap(b, off, len);
-            while (inputBuffer.hasRemaining()) {
-                // copy batch to part buffer
-                final int inputLimit = inputBuffer.limit();
-                final int toCopy = Math.min(partBuffer.remaining(), inputBuffer.remaining());
-                final int positionAfterCopying = inputBuffer.position() + toCopy;
-                inputBuffer.limit(positionAfterCopying);
-                partBuffer.put(inputBuffer.slice());
+            if (isClosed()) {
+                throw new IllegalStateException("Already closed");
+            }
+            if (b.length == 0) {
+                return;
+            }
+            try {
+                final ByteBuffer inputBuffer = ByteBuffer.wrap(b, off, len);
+                while (inputBuffer.hasRemaining()) {
+                    // copy batch to part buffer
+                    final int inputLimit = inputBuffer.limit();
+                    final int toCopy = Math.min(partBuffer.remaining(), inputBuffer.remaining());
+                    final int positionAfterCopying = inputBuffer.position() + toCopy;
+                    inputBuffer.limit(positionAfterCopying);
+                    partBuffer.put(inputBuffer.slice());
 
-                // prepare current batch for next part
-                inputBuffer.limit(inputLimit);
-                inputBuffer.position(positionAfterCopying);
+                    // prepare current batch for next part
+                    inputBuffer.limit(inputLimit);
+                    inputBuffer.position(positionAfterCopying);
 
-                if (!partBuffer.hasRemaining()) {
-                    if (uploadId == null){
-                        uploadId = createMultipartUploadRequest();
-                        // this is not expected (another exception should be thrown by S3) but adding for completeness
-                        if (uploadId == null || uploadId.isEmpty()) {
-                            throw new IOException("Failed to create multipart upload, uploadId is empty");
+                    if (!partBuffer.hasRemaining()) {
+                        if (uploadId == null){
+                            uploadId = createMultipartUploadRequest();
+                            // this is not expected (another exception should be thrown by S3) but adding for completeness
+                            if (uploadId == null || uploadId.isEmpty()) {
+                                throw new IOException("Failed to create multipart upload, uploadId is empty");
+                            }
                         }
+                        partBuffer.position(0);
+                        partBuffer.limit(partSize);
+                        flushBuffer(partBuffer.slice(), partSize, true);
                     }
-                    partBuffer.position(0);
-                    partBuffer.limit(partSize);
-                    flushBuffer(partBuffer.slice(), partSize, true);
                 }
+            } catch (final RuntimeException e) {
+                closed = true;
+                if (multiPartUploadStarted()) {
+                    log.error("Failed to write to stream on upload {}, aborting transaction", uploadId, e);
+                    abortUpload();
+                }
+                throw new IOException(e);
             }
-        } catch (final RuntimeException e) {
-            closed = true;
-            if (multiPartUploadStarted()) {
-                log.error("Failed to write to stream on upload {}, aborting transaction", uploadId, e);
-                abortUpload();
-            }
-            throw new IOException(e);
+        } catch (final Error t) {
+            log.error("[logzio-rsm-trace] S3UploadOutputStream.write ABORTED ABNORMALLY key={} uploadId={} cause={} message={}",
+                key.value(), uploadId, t.getClass().getName(), t.getMessage(), t);
+            throw t;
         }
     }
 
     private String createMultipartUploadRequest() {
+        log.debug("[logzio-rsm-trace] Entry: S3UploadOutputStream.createMultipartUploadRequest key={}",
+            key.value());
         final CreateMultipartUploadRequest initialRequest = CreateMultipartUploadRequest.builder().bucket(bucketName)
                 .storageClass(storageClass)
                 .key(key.value()).build();
         final CreateMultipartUploadResponse initiateResult = client.createMultipartUpload(initialRequest);
         log.debug("Create new multipart upload request: {}", initiateResult.uploadId());
+        log.debug("[logzio-rsm-trace] Exit: S3UploadOutputStream.createMultipartUploadRequest key={} uploadId={}",
+            key.value(), initiateResult.uploadId());
         return initiateResult.uploadId();
     }
 
@@ -151,42 +161,54 @@ public class S3UploadOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
-        if (!isClosed()) {
-            closed = true;
-            final int lastPosition = partBuffer.position();
-            if (lastPosition > 0) {
-                try {
-                    partBuffer.position(0);
-                    partBuffer.limit(lastPosition);
-                    flushBuffer(partBuffer.slice(), lastPosition, multiPartUploadStarted());
-                } catch (final RuntimeException e) {
-                    if (multiPartUploadStarted()) {
-                        log.error("Failed to upload last part {}, aborting transaction", uploadId, e);
-                        abortUpload();
-                    } else {
-                        log.error("Failed to upload the file {}", key, e);
+        try {
+            if (!isClosed()) {
+                closed = true;
+                final int lastPosition = partBuffer.position();
+                if (lastPosition > 0) {
+                    try {
+                        partBuffer.position(0);
+                        partBuffer.limit(lastPosition);
+                        flushBuffer(partBuffer.slice(), lastPosition, multiPartUploadStarted());
+                    } catch (final RuntimeException e) {
+                        if (multiPartUploadStarted()) {
+                            log.error("Failed to upload last part {}, aborting transaction", uploadId, e);
+                            abortUpload();
+                        } else {
+                            log.error("Failed to upload the file {}", key, e);
+                        }
+                        throw new IOException(e);
                     }
-                    throw new IOException(e);
+                }
+                if (multiPartUploadStarted()) {
+                    completeOrAbortMultiPartUpload();
                 }
             }
-            if (multiPartUploadStarted()) {
-                completeOrAbortMultiPartUpload();
-            }
+        } catch (final Error t) {
+            log.error("[logzio-rsm-trace] S3UploadOutputStream.close ABORTED ABNORMALLY key={} uploadId={} processedBytes={} cause={} message={}",
+                key.value(), uploadId, processedBytes, t.getClass().getName(), t.getMessage(), t);
+            throw t;
         }
     }
 
     private void completeOrAbortMultiPartUpload() throws IOException {
-        if (!completedParts.isEmpty()) {
-            try {
-                completeUpload();
-                log.debug("Completed multipart upload {}", uploadId);
-            } catch (final RuntimeException e) {
-                log.error("Failed to complete multipart upload {}, aborting transaction", uploadId, e);
+        try {
+            if (!completedParts.isEmpty()) {
+                try {
+                    completeUpload();
+                    log.debug("Completed multipart upload {}", uploadId);
+                } catch (final RuntimeException e) {
+                    log.error("Failed to complete multipart upload {}, aborting transaction", uploadId, e);
+                    abortUpload();
+                    throw new IOException(e);
+                }
+            } else {
                 abortUpload();
-                throw new IOException(e);
             }
-        } else {
-            abortUpload();
+        } catch (final Error t) {
+            log.error("[logzio-rsm-trace] S3UploadOutputStream.completeOrAbortMultiPartUpload ABORTED ABNORMALLY key={} uploadId={} cause={} message={}",
+                key.value(), uploadId, t.getClass().getName(), t.getMessage(), t);
+            throw t;
         }
     }
 
@@ -195,12 +217,16 @@ public class S3UploadOutputStream extends OutputStream {
      * The caller of this method should be responsible for closing the inputStream.
      */
     private void uploadAsSingleFile(final InputStream inputStream, final int size) {
+        log.debug("[logzio-rsm-trace] Entry: S3UploadOutputStream.uploadAsSingleFile key={} size={}",
+            key.value(), size);
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucketName)
             .storageClass(storageClass)
             .key(key.value())
             .build();
         final RequestBody requestBody = RequestBody.fromInputStream(inputStream, size);
         client.putObject(putObjectRequest, requestBody);
+        log.debug("[logzio-rsm-trace] Exit: S3UploadOutputStream.uploadAsSingleFile key={} size={}",
+            key.value(), size);
     }
 
     public boolean isClosed() {
@@ -208,25 +234,39 @@ public class S3UploadOutputStream extends OutputStream {
     }
 
     private void completeUpload() {
-        final CompletedMultipartUpload completedMultipartUpload = CompletedMultipartUpload.builder()
-            .parts(completedParts)
-            .build();
-        final var request = CompleteMultipartUploadRequest.builder()
-            .bucket(bucketName)
-            .key(key.value())
-            .uploadId(uploadId)
-            .multipartUpload(completedMultipartUpload)
-            .build();
-        client.completeMultipartUpload(request);
+        log.debug("[logzio-rsm-trace] Entry: S3UploadOutputStream.completeUpload key={} uploadId={} partCount={}",
+            key.value(), uploadId, completedParts.size());
+        try {
+            final CompletedMultipartUpload completedMultipartUpload = CompletedMultipartUpload.builder()
+                .parts(completedParts)
+                .build();
+            final var request = CompleteMultipartUploadRequest.builder()
+                .bucket(bucketName)
+                .key(key.value())
+                .uploadId(uploadId)
+                .multipartUpload(completedMultipartUpload)
+                .build();
+            client.completeMultipartUpload(request);
+            log.debug("[logzio-rsm-trace] Exit: S3UploadOutputStream.completeUpload key={} uploadId={} outcome=completed",
+                key.value(), uploadId);
+        } catch (final Error t) {
+            log.error("[logzio-rsm-trace] S3UploadOutputStream.completeUpload ABORTED ABNORMALLY key={} uploadId={} cause={} message={}",
+                key.value(), uploadId, t.getClass().getName(), t.getMessage(), t);
+            throw t;
+        }
     }
 
     private void abortUpload() {
+        log.debug("[logzio-rsm-trace] Entry: S3UploadOutputStream.abortUpload key={} uploadId={}",
+            key.value(), uploadId);
         final var request = AbortMultipartUploadRequest.builder()
             .bucket(bucketName)
             .key(key.value())
             .uploadId(uploadId)
             .build();
         client.abortMultipartUpload(request);
+        log.debug("[logzio-rsm-trace] Exit: S3UploadOutputStream.abortUpload key={} uploadId={}",
+            key.value(), uploadId);
     }
 
     private void flushBuffer(final ByteBuffer buffer,
@@ -248,6 +288,8 @@ public class S3UploadOutputStream extends OutputStream {
 
     private void uploadPart(final InputStream in, final int actualPartSize) {
         final int partNumber = completedParts.size() + 1;
+        log.debug("[logzio-rsm-trace] Entry: S3UploadOutputStream.uploadPart key={} uploadId={} partNumber={} partSize={}",
+            key.value(), uploadId, partNumber, actualPartSize);
         final UploadPartRequest uploadPartRequest =
             UploadPartRequest.builder()
                 .bucket(bucketName)
@@ -262,6 +304,8 @@ public class S3UploadOutputStream extends OutputStream {
             .eTag(uploadResult.eTag())
             .build();
         completedParts.add(completedPart);
+        log.debug("[logzio-rsm-trace] Exit: S3UploadOutputStream.uploadPart key={} uploadId={} partNumber={} eTag={}",
+            key.value(), uploadId, partNumber, uploadResult.eTag());
     }
 
     long processedBytes() {


### PR DESCRIPTION
## What this is

Our **prod-validation branch** for #820 (`copyLogSegmentData` silent stall). It carries internal instrumentation + fault-injection + a superseded attempt alongside the proposed fix. A focused, clean PR (the catch-OOM-retry change only) will follow once our 7-day prod soak completes — opening this now so the approach and the production evidence are visible.

## Root cause (see the [2026-05-17 comment](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/issues/820#issuecomment-4471772446))

An unchecked `OutOfMemoryError` (from the eager `partSize` `ByteBuffer` allocation in `S3UploadOutputStream`) escapes the `catch (RuntimeException)` blocks in `KafkaRemoteStorageManager.copyLogSegmentData` and `RemoteStorageManager.copyLogSegmentData`. `RLMTask.run()` catches `Exception`, not `Throwable`, so the `Error` is never handled → `ScheduledThreadPoolExecutor` silently stops rescheduling `$RLMCopyTask` for that partition → uploads stop, local segments are never purged (no `COPY_SEGMENT_FINISHED`) → unbounded local bloat, with no completion log and no exception (the "never returns, never throws" symptom).

## Proposed fix (commits `3e4640a` + `55521df`)

Catch `OutOfMemoryError` at the `copyLogSegmentData` boundary, clean the orphan `COPY_SEGMENT_STARTED`, and rethrow as a **retriable** `RemoteStorageException` so the existing `$RLMCopyTask` retry path takes over on the next cycle:

```java
} catch (final OutOfMemoryError oom) {
    log.error("... copyLogSegmentData OOM metadata={}", remoteLogSegmentMetadata, oom);
    try {
        deleteSegmentObjects(remoteLogSegmentMetadata);
    } catch (final Exception ex) {
        log.warn("Removing orphan files failed after OOM", ex);
    }
    throw new RemoteStorageException("OOM during S3 upload; retryable", oom);
}
```

~17 lines across `KafkaRemoteStorageManager` + `RemoteStorageManager`. (The `[logzio-rsm-trace]` log prefix and the adjacent `catch (Error t)` ABORTED-logging on this branch are our instrumentation, not part of the proposed change.)

## Production validation

Deployed on `prod-us-east-1-kafka-7` (8 brokers, our highest-#820-incidence cluster) on 2026-05-25; 7-day soak in progress.

- **T+48 h: green.** 2 real prod OOMs (2026-05-25 12:34 UTC, 2026-05-26 23:15 UTC) — **both self-healed in ~33 s** (orphan cleaned → fresh upload of the same offset range → `COPY_SEGMENT_FINISHED`), versus the multi-day silent stall + manual leader-swap this used to require.
- One self-healed segment was end-to-end consume-validated from S3 (1 chunk retrieved, 0 fetch errors).

## Scope / relationship to a complete fix

This is a **resilience fix**: it makes the failure *recoverable* and *observable*, restoring the "completion-log-or-`RemoteStorageException`" contract for the OOM case. It is **complementary to**, not a replacement for:

- eliminating the oversized `partSize` allocation in `S3UploadOutputStream` (the OOM trigger), and/or
- widening the catch to handle non-`OutOfMemoryError` `Error`s.

Happy to shape the focused PR to whatever you prefer (catch scope, log wording, tests).

## Not for merge — experiment scaffolding on this branch

- `399568c` — `[logzio-rsm-trace]` instrumentation
- `518ea44` / `e4c4c4a` — fault-injection test hooks
- `cf8b6e5` — lazy-cache `partBuffer` attempt (**superseded; did not prevent the OOM in prod**)
- `d066c999` — cherry-pick of #801 (MetricCollector shared state)
