### PR TITLE
[WIP] feat: add DirectMemoryChunkCache for off-heap chunk caching

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -30,6 +30,8 @@ ext {
 
 dependencies {
     implementation project(':core')
+    implementation project(':storage:core')
+    implementation "com.github.ben-manes.caffeine:caffeine:3.2.3"
     implementation group: "org.apache.kafka", name: "kafka-storage-api", version: kafkaVersion
     implementation group: "org.apache.kafka", name: "kafka-clients", version: kafkaVersion
 

--- a/benchmarks/common.sh
+++ b/benchmarks/common.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+HEAP_SIZE="${HEAP_SIZE:-6g}"
+# memory cache stores chunks on heap, so it needs a larger heap than other types.
+MEMORY_HEAP_SIZE="${MEMORY_HEAP_SIZE:-12g}"
+DIRECT_MEM_SIZE="${DIRECT_MEM_SIZE:-8g}"
+G1_REGION_SIZE="${G1_REGION_SIZE-16m}"
+THREADS="${THREADS:-16}"
+CACHE_SIZE="${CACHE_SIZE:-6442450944}"
+CHUNK_SIZE="${CHUNK_SIZE:-4194304}"
+FETCH_CHUNKS="${FETCH_CHUNKS:-4}"
+
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$BENCH_DIR/.." && pwd)"
+
+build_jvm_opts() {
+    local heap="${1:-$HEAP_SIZE}"
+    local opts="-Xmx${heap} -XX:+UseG1GC -XX:MaxDirectMemorySize=${DIRECT_MEM_SIZE}"
+    if [ -n "$G1_REGION_SIZE" ]; then
+        opts="$opts -XX:G1HeapRegionSize=${G1_REGION_SIZE}"
+    fi
+    echo "$opts"
+}
+
+build_jar() {
+    echo "=== Building shadow JAR ==="
+    (cd "$PROJECT_DIR" && ./gradlew :benchmarks:shadowJar -q)
+    JAR=$(ls "$PROJECT_DIR"/benchmarks/build/libs/kafka-ts-benchmarks-*-all.jar | head -1)
+    echo "JAR: $JAR"
+}
+
+# Create a timestamped results dir; sets global RESULTS_DIR. Arg: tag prefix.
+make_results_dir() {
+    local tag="${1:-bench}"
+    local run_id="$(date +%Y%m%d_%H%M%S)_${tag}_heap${HEAP_SIZE}_cache${CACHE_SIZE}_chunk${CHUNK_SIZE}_t${THREADS}"
+    RESULTS_DIR="$PROJECT_DIR/benchmarks/results/${run_id}"
+    mkdir -p "$RESULTS_DIR"
+    echo "Results: $RESULTS_DIR"
+}

--- a/benchmarks/scenario.sh
+++ b/benchmarks/scenario.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Scenario benchmark driver (non-JMH; runs ChunkCacheScenarioBench main directly).
+# Usage: ./benchmarks/scenario.sh
+#
+# For a pure uniform-random GC stress run, zero out the other three thread ratios:
+#   HOT_THREAD_RATIO=0 WARM_THREAD_RATIO=0 COLD_THREAD_RATIO=0 RANDOM_THREAD_RATIO=1 \
+#     PREFILL=true ./benchmarks/scenario.sh
+#
+# Each cacheType runs in its own JVM, so heap can be sized per type — memory uses
+# MEMORY_HEAP_SIZE, others use HEAP_SIZE.
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+SCENARIO_MAIN="io.aiven.kafka.tieredstorage.benchs.cache.ChunkCacheScenarioBench"
+
+# Scenario-specific config (env-overridable). Shared knobs live in common.sh.
+SEGMENTS="${SEGMENTS:-512}"
+CHUNKS_PER_SEG="${CHUNKS_PER_SEG:-64}"
+DURATION="${DURATION:-600}"
+MISS_LATENCY_MS="${MISS_LATENCY_MS:-0}"
+HOT_RATIO="${HOT_RATIO:-0.1}"
+WARM_RATIO="${WARM_RATIO:-0.2}"
+DISK_PATH="${DISK_PATH:-}"
+
+# Thread mix; defaults reproduce the original 16-thread 10/4/1/1 split.
+HOT_THREAD_RATIO="${HOT_THREAD_RATIO:-10}"
+WARM_THREAD_RATIO="${WARM_THREAD_RATIO:-4}"
+COLD_THREAD_RATIO="${COLD_THREAD_RATIO:-1}"
+RANDOM_THREAD_RATIO="${RANDOM_THREAD_RATIO:-1}"
+
+PREFILL="${PREFILL:-false}"
+
+run_scenario() {
+    # With prefill, size the working set to exactly fit the cache so every entry stays
+    # warm and the run is pure cache-hit; otherwise eviction during prefill makes it
+    # meaningless. Without prefill, use configured SEGMENTS/CHUNKS_PER_SEG to drive eviction.
+    local seg=$SEGMENTS cps=$CHUNKS_PER_SEG
+    if [ "$PREFILL" = "true" ]; then
+        seg=$((CACHE_SIZE / CHUNK_SIZE)); cps=1
+    fi
+
+    echo "=== ChunkCacheScenarioBench region (threadMix=$HOT_THREAD_RATIO/$WARM_THREAD_RATIO/$COLD_THREAD_RATIO/$RANDOM_THREAD_RATIO prefill=$PREFILL segments=$seg chunks=$cps, ${DURATION}s each) ==="
+
+    local disk_opt=""
+    [ -n "$DISK_PATH" ] && mkdir -p "$DISK_PATH" && disk_opt="--disk-path $DISK_PATH"
+
+    for type in memory refcount-direct disk; do
+        echo "--- $type ---"
+
+        local heap=$HEAP_SIZE
+        [ "$type" = "memory" ] && heap=$MEMORY_HEAP_SIZE
+
+        java $(build_jvm_opts "$heap") \
+            -Xlog:gc*:file="$RESULTS_DIR/region_gc_${type}.log":time,tags \
+            -cp "$JAR" \
+            "$SCENARIO_MAIN" \
+            "$type" --cache-size $CACHE_SIZE --chunk-size $CHUNK_SIZE \
+            --duration $DURATION --threads $THREADS \
+            --segments $seg --chunks-per-segment $cps \
+            --miss-latency-ms $MISS_LATENCY_MS --fetch-chunks $FETCH_CHUNKS \
+            --hot-ratio $HOT_RATIO --warm-ratio $WARM_RATIO \
+            --hot-thread-ratio $HOT_THREAD_RATIO --warm-thread-ratio $WARM_THREAD_RATIO \
+            --cold-thread-ratio $COLD_THREAD_RATIO --random-thread-ratio $RANDOM_THREAD_RATIO \
+            --prefill $PREFILL \
+            $disk_opt \
+            | tee "$RESULTS_DIR/region_${type}.txt"
+        echo ""
+    done
+}
+
+build_jar
+make_results_dir region
+echo "Config: heap=$HEAP_SIZE memHeap=$MEMORY_HEAP_SIZE direct=$DIRECT_MEM_SIZE region=${G1_REGION_SIZE:-JVM-default} threads=$THREADS cache=$CACHE_SIZE chunk=$CHUNK_SIZE"
+
+run_scenario
+
+echo "=== Done. Results in $RESULTS_DIR/ ==="

--- a/benchmarks/src/main/java/io/aiven/kafka/tieredstorage/benchs/cache/CacheBenchUtils.java
+++ b/benchmarks/src/main/java/io/aiven/kafka/tieredstorage/benchs/cache/CacheBenchUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.benchs.cache;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.DirectMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.DiskChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.MemoryChunkCache;
+
+public final class CacheBenchUtils {
+
+    private CacheBenchUtils() {
+    }
+
+    public static ChunkCache<?> createCache(final String type, final ChunkManager cm,
+                                            final int chunkSize, final long cacheSize,
+                                            final Path diskPath) throws Exception {
+        final ChunkCache<?> c = switch (type) {
+            case "memory" -> new MemoryChunkCache(cm);
+            case "refcount-direct" -> new DirectMemoryChunkCache(cm);
+            case "disk" -> new DiskChunkCache(cm);
+            default -> throw new IllegalArgumentException("Unknown cache type: " + type);
+        };
+
+        final Map<String, String> config = new HashMap<>();
+        config.put("size", String.valueOf(cacheSize));
+        config.put("retention.ms", "-1");
+        // Used only by DirectMemoryChunkCache to size its DirectByteBufferPool (bufferSize and
+        // maxPoolSize = cacheSize / bufferSize). Other cache types ignore this key.
+        config.put("chunk.size", String.valueOf(chunkSize));
+        config.put("thread.pool.size", String.valueOf(Runtime.getRuntime().availableProcessors() * 2));
+
+        if ("disk".equals(type)) {
+            final Path dir = diskPath != null ? diskPath : Files.createTempDirectory("bench-cache");
+            config.put("path", dir.toString());
+            if (diskPath == null) {
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> deleteRecursively(dir)));
+            }
+        }
+
+        c.configure(config);
+        return c;
+    }
+
+    /** Best-effort recursive delete of a directory tree; ignores failures. */
+    public static void deleteRecursively(final Path dir) {
+        try {
+            Files.walk(dir)
+                .sorted(Comparator.reverseOrder())
+                .forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (final Exception ignored) {
+                        // best-effort cleanup
+                    }
+                });
+        } catch (final Exception ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    public static long totalGcCount() {
+        return ManagementFactory.getGarbageCollectorMXBeans().stream()
+            .mapToLong(GarbageCollectorMXBean::getCollectionCount).sum();
+    }
+
+    public static long totalGcTimeMs() {
+        return ManagementFactory.getGarbageCollectorMXBeans().stream()
+            .mapToLong(GarbageCollectorMXBean::getCollectionTime).sum();
+    }
+}

--- a/benchmarks/src/main/java/io/aiven/kafka/tieredstorage/benchs/cache/ChunkCacheScenarioBench.java
+++ b/benchmarks/src/main/java/io/aiven/kafka/tieredstorage/benchs/cache/ChunkCacheScenarioBench.java
@@ -1,0 +1,652 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.benchs.cache;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
+
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
+import io.aiven.kafka.tieredstorage.fetch.cache.ChunkCache;
+import io.aiven.kafka.tieredstorage.fetch.cache.DirectMemoryChunkCache;
+import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
+import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
+import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;
+import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
+import io.aiven.kafka.tieredstorage.storage.ObjectKey;
+
+/**
+ * Cache scenario benchmark simulating realistic Kafka tiered storage read patterns.
+ *
+ * <p>Segments are partitioned into HOT / WARM / COLD regions. HOT threads scan a small
+ * hot region (tail consumers), WARM threads scan a larger warm region, COLD threads
+ * sweep all segments sequentially, RANDOM threads do uniform random reads. Cache hits
+ * emerge from thread overlap within regions.</p>
+ *
+ * <p>Two independent ratio sets control the simulation:</p>
+ * <ul>
+ *   <li><b>Region size</b> ({@code --hot-ratio}, {@code --warm-ratio}) — fraction of
+ *       segments in HOT / WARM; the rest is COLD.</li>
+ *   <li><b>Thread mix</b> ({@code --hot-thread-ratio}, {@code --warm-thread-ratio},
+ *       {@code --cold-thread-ratio}, {@code --random-thread-ratio}) — fraction of threads
+ *       per type. Normalised and assigned via largest-remainder so per-type counts sum
+ *       to {@code --threads}.</li>
+ * </ul>
+ *
+ * <p>The printed overlap ratio (HOT segs / HOT threads) shows whether a config will
+ * actually produce hits. A pure uniform-random GC-stress run is the special case
+ * {@code --random-thread-ratio 1.0 --prefill true}.</p>
+ *
+ * <p>Each operation reads {@code fetchChunks} consecutive chunks into one buffer,
+ * mimicking a Kafka broker fetch spanning multiple chunks via FetchChunkEnumeration.</p>
+ */
+public class ChunkCacheScenarioBench {
+
+    private static final int WARMUP_SECONDS = 30;
+    private static final int REPORT_INTERVAL_SECONDS = 30;
+
+    enum ConsumerType {
+        /** Threads sharing a small hot region — tail consumers. */
+        HOT,
+        /** Reads the warm region (recent but not newest segments). */
+        WARM,
+        /** Sequential scan through all segments (catch-up / reprocessing). */
+        COLD,
+        /** Uniform random access across all segments. */
+        RANDOM
+    }
+
+    private final Config config;
+    private final ObjectKey[] objectKeys;
+    private final SegmentManifest[] manifests;
+    private final ChunkCache<?> cache;
+
+    // Region boundaries: [0, warmStart) = cold, [warmStart, hotStart) = warm, [hotStart, total) = hot
+    private final int hotStart;
+    private final int warmStart;
+
+    // Per-thread consumer type, indexed by threadId. Computed once via largest-remainder.
+    private final ConsumerType[] assignment;
+
+    private final AtomicLong[] opsByType = new AtomicLong[ConsumerType.values().length];
+    private final AtomicLong totalOps = new AtomicLong();
+    private final AtomicLong errorCount = new AtomicLong();
+    private final ConcurrentHashMap<ConsumerType, List<long[]>> latenciesByType = new ConcurrentHashMap<>();
+
+    record Config(String cacheType, long cacheSize, int chunkSize,
+                  int durationSeconds, int totalThreads, int totalSegments,
+                  int chunksPerSegment, int missLatencyMs, int fetchChunks,
+                  boolean prefill, String diskPath,
+                  double hotRatio, double warmRatio,
+                  double hotThreadRatio, double warmThreadRatio,
+                  double coldThreadRatio, double randomThreadRatio) {
+    }
+
+    public ChunkCacheScenarioBench(final Config config) throws Exception {
+        this.config = config;
+
+        for (int i = 0; i < opsByType.length; i++) {
+            opsByType[i] = new AtomicLong();
+        }
+        for (final ConsumerType ct : ConsumerType.values()) {
+            latenciesByType.put(ct, new ArrayList<>());
+        }
+
+        // Validate up front so misconfiguration fails fast instead of producing
+        // negative segment indices or a degenerate thread assignment.
+        if (config.hotRatio() + config.warmRatio() >= 1.0) {
+            throw new IllegalArgumentException(String.format(
+                "hot-ratio + warm-ratio must be < 1.0 (leave room for COLD region): %.3f + %.3f",
+                config.hotRatio(), config.warmRatio()));
+        }
+
+        // Region layout: [0, warmStart) = cold, [warmStart, hotStart) = warm, [hotStart, N) = hot
+        final int hotSize = Math.max(1, (int) (config.totalSegments() * config.hotRatio()));
+        final int warmSize = Math.max(1, (int) (config.totalSegments() * config.warmRatio()));
+        this.hotStart = config.totalSegments() - hotSize;
+        this.warmStart = this.hotStart - warmSize;
+
+        this.assignment = buildAssignment();
+
+        this.cache = createCache(config);
+        this.objectKeys = new ObjectKey[config.totalSegments()];
+        this.manifests = new SegmentManifest[config.totalSegments()];
+        initSegments();
+    }
+
+    /**
+     * Distributes {@code totalThreads} across the four consumer types via largest-remainder:
+     * each type's right boundary is {@code round(cumulativeRatio * totalThreads)}; the last
+     * type runs to {@code totalThreads} to absorb rounding drift. Threads are laid out
+     * HOT, WARM, COLD, RANDOM by threadId.
+     */
+    private ConsumerType[] buildAssignment() {
+        final ConsumerType[] types = ConsumerType.values();
+        final double[] ratios = {
+            config.hotThreadRatio(), config.warmThreadRatio(),
+            config.coldThreadRatio(), config.randomThreadRatio(),
+        };
+        double sum = 0;
+        for (final double r : ratios) {
+            if (r < 0) {
+                throw new IllegalArgumentException("thread ratios must be >= 0");
+            }
+            sum += r;
+        }
+        if (sum <= 0) {
+            throw new IllegalArgumentException("at least one thread ratio must be > 0");
+        }
+
+        final int n = config.totalThreads();
+        final ConsumerType[] result = new ConsumerType[n];
+        int idx = 0;
+        double cumulative = 0;
+        for (int i = 0; i < types.length; i++) {
+            cumulative += ratios[i] / sum;
+            // Last type runs to n, absorbing rounding so the array is fully filled.
+            final int end = (i == types.length - 1) ? n : (int) Math.round(cumulative * n);
+            while (idx < end) {
+                result[idx++] = types[i];
+            }
+        }
+        return result;
+    }
+
+    private void initSegments() {
+        final int segmentFileSize = config.chunkSize() * config.chunksPerSegment();
+        final SegmentIndexesV1 indexes = SegmentIndexesV1.builder()
+            .add(IndexType.OFFSET, 1)
+            .add(IndexType.TIMESTAMP, 1)
+            .add(IndexType.PRODUCER_SNAPSHOT, 1)
+            .add(IndexType.LEADER_EPOCH, 1)
+            .add(IndexType.TRANSACTION, 1)
+            .build();
+
+        for (int i = 0; i < config.totalSegments(); i++) {
+            final String key = "tp-" + (i % 100) + "/seg-" + i;
+            objectKeys[i] = () -> key;
+            manifests[i] = new SegmentManifestV1(
+                new FixedSizeChunkIndex(config.chunkSize(), segmentFileSize, config.chunkSize(), config.chunkSize()),
+                indexes, false, null, null);
+        }
+    }
+
+    private static ChunkCache<?> createCache(final Config config) throws Exception {
+        final byte[] templateData = new byte[config.chunkSize()];
+        ThreadLocalRandom.current().nextBytes(templateData);
+
+        final ChunkManager mockChunkManager = (objectKey, manifest, chunkId) -> {
+            if (config.missLatencyMs() > 0) {
+                try {
+                    Thread.sleep(config.missLatencyMs());
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return new ByteArrayInputStream(templateData);
+        };
+
+        final Path diskPath = config.diskPath() != null ? Path.of(config.diskPath()) : null;
+        return CacheBenchUtils.createCache(
+            config.cacheType(), mockChunkManager, config.chunkSize(), config.cacheSize(), diskPath);
+    }
+
+    public void run() throws Exception {
+        final int warmupSeconds = Math.min(WARMUP_SECONDS, config.durationSeconds() / 3);
+        final int measuredSeconds = config.durationSeconds() - warmupSeconds;
+
+        printHeader(warmupSeconds, measuredSeconds);
+        if (config.prefill()) {
+            prefillCache();
+        }
+
+        final long startNano = System.nanoTime();
+        final long deadline = startNano + (long) config.durationSeconds() * 1_000_000_000L;
+        final long warmupEnd = startNano + (long) warmupSeconds * 1_000_000_000L;
+
+        final long[] gcAtWarmupEnd = runBenchmark(deadline, warmupEnd, startNano);
+        printResults(warmupSeconds, measuredSeconds, startNano, gcAtWarmupEnd);
+    }
+
+    private long[] runBenchmark(final long deadline, final long warmupEnd, final long startNano)
+        throws InterruptedException {
+        final CountDownLatch done = new CountDownLatch(config.totalThreads());
+        final long gcCountBefore = CacheBenchUtils.totalGcCount();
+        final long gcTimeBefore = CacheBenchUtils.totalGcTimeMs();
+        final long[] gcAtWarmupEnd = new long[2];
+
+        // Launch consumer threads
+        for (int t = 0; t < config.totalThreads(); t++) {
+            final ConsumerType type = assignConsumerType(t);
+            final int threadId = t;
+            new Thread(() -> {
+                try {
+                    runConsumer(type, threadId, deadline, warmupEnd);
+                } catch (final Exception e) {
+                    errorCount.incrementAndGet();
+                    e.printStackTrace();
+                } finally {
+                    done.countDown();
+                }
+            }, "consumer-" + t + "-" + type).start();
+        }
+
+        // Snapshot GC at warmup end
+        final long sleepForWarmup = (warmupEnd - System.nanoTime()) / 1_000_000L;
+        if (sleepForWarmup > 0) {
+            Thread.sleep(sleepForWarmup);
+        }
+        gcAtWarmupEnd[0] = CacheBenchUtils.totalGcCount() - gcCountBefore;
+        gcAtWarmupEnd[1] = CacheBenchUtils.totalGcTimeMs() - gcTimeBefore;
+
+        startReporter(deadline, warmupEnd, startNano);
+        done.await();
+        return gcAtWarmupEnd;
+    }
+
+    private void startReporter(final long deadline, final long warmupEnd, final long startNano) {
+        final Thread reporter = new Thread(() -> {
+            try {
+                while (System.nanoTime() < deadline) {
+                    Thread.sleep(REPORT_INTERVAL_SECONDS * 1000L);
+                    final long now = System.nanoTime();
+                    final long elapsed = Math.max(1, (now - warmupEnd) / 1_000_000_000L);
+                    final long ops = totalOps.get();
+                    System.out.printf("[%3ds] ops=%d, throughput=%d ops/s, GC count=%d, GC time=%dms%n",
+                        (now - startNano) / 1_000_000_000L, ops, ops / elapsed,
+                        CacheBenchUtils.totalGcCount(), CacheBenchUtils.totalGcTimeMs());
+                }
+            } catch (final InterruptedException ignored) {
+                // reporter shutdown
+            }
+        }, "reporter");
+        reporter.setDaemon(true);
+        reporter.start();
+    }
+
+    private void runConsumer(final ConsumerType type, final int threadId,
+                             final long deadline, final long warmupEnd) throws Exception {
+        final ByteBuffer buf = ByteBuffer.allocate(config.chunkSize() * config.fetchChunks());
+        long[] localLatencies = new long[200000];
+        int latencyIdx = 0;
+
+        int segIdx = pickInitialSegment(type, threadId);
+        int chunkIdx = 0;
+
+        while (System.nanoTime() < deadline) {
+            final int seg;
+            final int startChunk;
+
+            if (type == ConsumerType.RANDOM) {
+                seg = ThreadLocalRandom.current().nextInt(config.totalSegments());
+                startChunk = ThreadLocalRandom.current().nextInt(
+                    Math.max(1, config.chunksPerSegment() - config.fetchChunks() + 1));
+            } else {
+                seg = segIdx;
+                startChunk = chunkIdx;
+                chunkIdx += config.fetchChunks();
+                if (chunkIdx >= config.chunksPerSegment()) {
+                    chunkIdx = 0;
+                    segIdx = pickNextSegment(type, segIdx);
+                }
+            }
+
+            final long opStart = System.nanoTime();
+            readChunks(seg, startChunk, buf);
+            final long opEnd = System.nanoTime();
+
+            // Skip warmup period
+            if (opEnd >= warmupEnd) {
+                totalOps.incrementAndGet();
+                opsByType[type.ordinal()].incrementAndGet();
+                if (latencyIdx >= localLatencies.length) {
+                    localLatencies = Arrays.copyOf(localLatencies, localLatencies.length * 2);
+                }
+                localLatencies[latencyIdx++] = (opEnd - opStart) / 1000L; // nanos -> micros
+            }
+        }
+
+        synchronized (latenciesByType.get(type)) {
+            latenciesByType.get(type).add(Arrays.copyOf(localLatencies, latencyIdx));
+        }
+    }
+
+    /**
+     * Reads consecutive chunks into a single buffer, mirroring the broker's
+     * {@code Utils.readFully(remoteSegInputStream, fetchBuffer)} loop in
+     * {@code RemoteLogManager.read()}.
+     */
+    private void readChunks(final int seg, final int startChunk, final ByteBuffer buf) throws Exception {
+        final int endChunk = Math.min(startChunk + config.fetchChunks(), config.chunksPerSegment());
+        buf.clear();
+        for (int c = startChunk; c < endChunk; c++) {
+            if (!buf.hasRemaining()) {
+                break;
+            }
+            try (InputStream is = cache.getChunk(objectKeys[seg], manifests[seg], c)) {
+                Utils.readFully(is, buf);
+            }
+        }
+    }
+
+    private int pickInitialSegment(final ConsumerType type, final int threadId) {
+        return switch (type) {
+            case HOT -> hotStart + ThreadLocalRandom.current().nextInt(config.totalSegments() - hotStart);
+            case WARM -> warmStart + ThreadLocalRandom.current().nextInt(hotStart - warmStart);
+            case COLD -> threadId % Math.max(1, warmStart);
+            default -> 0;
+        };
+    }
+
+    private int pickNextSegment(final ConsumerType type, final int currentSeg) {
+        return switch (type) {
+            case HOT -> currentSeg + 1 >= config.totalSegments() ? hotStart : currentSeg + 1;
+            case WARM -> currentSeg + 1 >= hotStart ? warmStart : currentSeg + 1;
+            case COLD -> (currentSeg + 1) % config.totalSegments();
+            default -> currentSeg;
+        };
+    }
+
+    private ConsumerType assignConsumerType(final int threadId) {
+        return assignment[threadId];
+    }
+
+    private void printHeader(final int warmupSeconds, final int measuredSeconds) {
+        final long workingSetMb =
+            (long) config.totalSegments() * config.chunksPerSegment() * config.chunkSize() / (1024 * 1024);
+
+        // Per-type thread counts from the resolved assignment.
+        final int[] threadCounts = new int[ConsumerType.values().length];
+        for (final ConsumerType ct : assignment) {
+            threadCounts[ct.ordinal()]++;
+        }
+        final int hotThreads = threadCounts[ConsumerType.HOT.ordinal()];
+        final int warmThreads = threadCounts[ConsumerType.WARM.ordinal()];
+        final int hotSegs = config.totalSegments() - hotStart;
+        final int warmSegs = hotStart - warmStart;
+
+        System.out.printf("=== Region-Based Cache Scenario ===%n");
+        System.out.printf("Segments: %d (%d chunks each), Working set: %dMB%n",
+            config.totalSegments(), config.chunksPerSegment(), workingSetMb);
+        System.out.printf("Regions: HOT[%d-%d] %d segs / %d threads, WARM[%d-%d] %d segs / %d threads, "
+                + "COLD[0-%d] %d segs / %d threads, RANDOM %d threads%n",
+            hotStart, config.totalSegments() - 1, hotSegs, hotThreads,
+            warmStart, hotStart - 1, warmSegs, warmThreads,
+            warmStart - 1, warmStart, threadCounts[ConsumerType.COLD.ordinal()],
+            threadCounts[ConsumerType.RANDOM.ordinal()]);
+        // Overlap = segments per thread within a region. < 1.0 means threads share
+        // segments (hits emerge from overlap); >> 1.0 means too sparse for sharing.
+        System.out.printf("Overlap (segs/thread): HOT %.3f, WARM %.3f  (lower = more sharing = higher hit rate)%n",
+            hotThreads > 0 ? (double) hotSegs / hotThreads : Double.NaN,
+            warmThreads > 0 ? (double) warmSegs / warmThreads : Double.NaN);
+        System.out.printf("Threads: %d, Duration: %ds (warmup: %ds, measurement: %ds)%n",
+            config.totalThreads(), config.durationSeconds(), warmupSeconds, measuredSeconds);
+        System.out.printf("Prefill: %b, Miss latency: %dms, Fetch chunks: %d%n%n",
+            config.prefill(), config.missLatencyMs(), config.fetchChunks());
+    }
+
+    private void prefillCache() throws Exception {
+        // Prefill only fully warms the cache when the working set fits. If it exceeds
+        // cacheSize, Caffeine evicts during the sweep and only the last ~cacheSize entries
+        // survive, so the run still misses heavily. Warn instead of silently misleading.
+        final long workingSet = (long) config.totalSegments() * config.chunksPerSegment() * config.chunkSize();
+        if (workingSet > config.cacheSize()) {
+            System.out.printf("WARNING: working set %dMB > cache %dMB — prefill cannot fully warm the cache, "
+                    + "subsequent reads will still miss. Reduce --segments/--chunks-per-segment so that "
+                    + "segments*chunksPerSegment*chunkSize <= cache-size.%n",
+                workingSet / (1024 * 1024), config.cacheSize() / (1024 * 1024));
+        }
+        System.out.printf("Pre-filling cache...%n");
+        for (int i = 0; i < config.totalSegments(); i++) {
+            for (int c = 0; c < config.chunksPerSegment(); c++) {
+                try (InputStream is = cache.getChunk(objectKeys[i], manifests[i], c)) {
+                    is.readAllBytes();
+                }
+            }
+        }
+        System.out.printf("Pre-fill done (%d entries)%n%n",
+            config.totalSegments() * config.chunksPerSegment());
+    }
+
+    private void printResults(final int warmupSeconds, final int measuredSeconds,
+                              final long startNano, final long[] gcDuringWarmup) {
+        final long measuredOps = totalOps.get();
+        final long gcCount = CacheBenchUtils.totalGcCount();
+        final long gcTime = CacheBenchUtils.totalGcTimeMs();
+
+        System.out.printf("%n=== Results (excluding %ds warmup) ===%n", warmupSeconds);
+        System.out.printf("Total ops:       %d%n", measuredOps);
+        System.out.printf("Throughput:      %d ops/s%n", measuredOps / Math.max(1, measuredSeconds));
+        System.out.printf("GC count:        %d%n", gcCount);
+        System.out.printf("GC time (ms):    %d%n", gcTime);
+        if (measuredOps > 0) {
+            System.out.printf("GC time/op:      %.4f ms%n", (double) gcTime / measuredOps);
+        }
+        System.out.printf("Warmup GC:       count=%d time=%dms%n", gcDuringWarmup[0], gcDuringWarmup[1]);
+
+        if (errorCount.get() > 0) {
+            System.out.printf("%n*** RESULT MAY BE INVALID: %d thread(s) failed ***%n", errorCount.get());
+        }
+
+        // Per-type breakdown
+        System.out.printf("%nOps by consumer type:%n");
+        for (final ConsumerType ct : ConsumerType.values()) {
+            System.out.printf("  %-8s %d%n", ct, opsByType[ct.ordinal()].get());
+        }
+
+        // GC collector details
+        System.out.printf("%nGC collectors:%n");
+        for (final GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
+            System.out.printf("  %s: count=%d time=%dms%n",
+                gc.getName(), gc.getCollectionCount(), gc.getCollectionTime());
+        }
+
+        printCacheStats();
+        printLatencyStats();
+    }
+
+    private void printCacheStats() {
+        final var stats = cache.cacheStats();
+        System.out.printf("%nCache stats:%n");
+        System.out.printf("  Hit count:       %d%n", stats.hitCount());
+        System.out.printf("  Miss count:      %d%n", stats.missCount());
+        System.out.printf("  Hit rate:        %.2f%%%n",
+            stats.hitCount() * 100.0 / Math.max(1, stats.requestCount()));
+        System.out.printf("  Eviction count:  %d%n", stats.evictionCount());
+        System.out.printf("  Eviction weight: %d bytes (%.1f MB)%n",
+            stats.evictionWeight(), stats.evictionWeight() / (1024.0 * 1024.0));
+        System.out.printf("  Estimated size:  %d entries%n", cache.estimatedSize());
+
+        if (cache instanceof DirectMemoryChunkCache) {
+            System.out.printf("  Buffer pool:     %d buffers pooled%n",
+                ((DirectMemoryChunkCache) cache).getBufferPool().currentPoolSize());
+        }
+    }
+
+    private void printLatencyStats() {
+        System.out.printf("%nLatency (us) by consumer type:%n");
+        System.out.printf("  %-8s %10s %10s %10s %10s %10s%n",
+            "Type", "p50", "p95", "p99", "p99.9", "max");
+
+        final List<long[]> allMerged = new ArrayList<>();
+        for (final ConsumerType ct : ConsumerType.values()) {
+            final long[] merged = mergeLatencies(latenciesByType.get(ct));
+            if (merged.length == 0) {
+                continue;
+            }
+            Arrays.sort(merged);
+            System.out.printf("  %-8s %10d %10d %10d %10d %10d%n", ct,
+                percentile(merged, 50), percentile(merged, 95),
+                percentile(merged, 99), percentile(merged, 99.9),
+                merged[merged.length - 1]);
+            allMerged.add(merged);
+        }
+        final long[] allLatencies = mergeLatencies(allMerged);
+        if (allLatencies.length > 0) {
+            Arrays.sort(allLatencies);
+            System.out.printf("  %-8s %10d %10d %10d %10d %10d%n", "ALL",
+                percentile(allLatencies, 50), percentile(allLatencies, 95),
+                percentile(allLatencies, 99), percentile(allLatencies, 99.9),
+                allLatencies[allLatencies.length - 1]);
+        }
+    }
+
+    private static long[] mergeLatencies(final List<long[]> arrays) {
+        int total = 0;
+        for (final long[] a : arrays) {
+            total += a.length;
+        }
+        final long[] result = new long[total];
+        int pos = 0;
+        for (final long[] a : arrays) {
+            System.arraycopy(a, 0, result, pos, a.length);
+            pos += a.length;
+        }
+        return result;
+    }
+
+    private static long percentile(final long[] sorted, final double p) {
+        final int idx = Math.min((int) (sorted.length * p / 100.0), sorted.length - 1);
+        return sorted[idx];
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Config config = parseArgs(args);
+        System.out.printf("Cache type: %s, cache size: %dMB, chunk size: %dMB%n",
+            config.cacheType(), config.cacheSize() / (1024 * 1024),
+            config.chunkSize() / (1024 * 1024));
+
+        new ChunkCacheScenarioBench(config).run();
+    }
+
+    private static Config parseArgs(final String[] args) {
+        if (args.length < 1 || "--help".equals(args[0]) || "-h".equals(args[0])) {
+            System.err.println("Usage: ChunkCacheScenarioBench <cacheType> [options]");
+            System.err.println("  Cache types: memory, refcount-direct, disk");
+            System.err.println("  --cache-size N         bytes (default: 268435456 = 256MB)");
+            System.err.println("  --chunk-size N         bytes (default: 4194304 = 4MB)");
+            System.err.println("  --duration N           seconds (default: 300)");
+            System.err.println("  --threads N            (default: 16)");
+            System.err.println("  --segments N           (default: 512)");
+            System.err.println("  --chunks-per-segment N (default: 64)");
+            System.err.println("  --miss-latency-ms N    simulated remote latency (default: 0)");
+            System.err.println("  --fetch-chunks N       chunks per fetch op (default: 1)");
+            System.err.println("  --disk-path PATH       disk cache directory (default: auto temp dir)");
+            System.err.println("  --hot-ratio N          fraction of segments in hot region (default: 0.1)");
+            System.err.println("  --warm-ratio N         fraction of segments in warm region (default: 0.2)");
+            System.err.println("  --hot-thread-ratio N     fraction of threads scanning hot region (default: 0.625)");
+            System.err.println("  --warm-thread-ratio N    fraction of threads scanning warm region (default: 0.25)");
+            System.err.println("  --cold-thread-ratio N    fraction of threads sweeping segments (default: 0.0625)");
+            System.err.println("  --random-thread-ratio N  fraction of threads doing random reads (default: 0.0625)");
+            System.err.println("  --prefill true|false   warm the whole cache before measuring (default: false)");
+            System.exit(1);
+        }
+
+        final String cacheType = args[0];
+        long cacheSize = 268435456;
+        int chunkSize = 4194304;
+        int duration = 300;
+        int threads = 16;
+        int segments = 512;
+        int chunksPerSegment = 64;
+        int missLatencyMs = 0;
+        int fetchChunks = 1;
+        boolean prefill = false;
+        String diskPath = null;
+        double hotRatio = 0.1;
+        double warmRatio = 0.2;
+        // Defaults reproduce the previous hard-coded 16-thread mix: 10 HOT / 4 WARM / 1 COLD / 1 RANDOM.
+        double hotThreadRatio = 0.625;
+        double warmThreadRatio = 0.25;
+        double coldThreadRatio = 0.0625;
+        double randomThreadRatio = 0.0625;
+
+        for (int i = 1; i < args.length - 1; i += 2) {
+            switch (args[i]) {
+                case "--cache-size":
+                    cacheSize = Long.parseLong(args[i + 1]);
+                    break;
+                case "--chunk-size":
+                    chunkSize = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--duration":
+                    duration = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--threads":
+                    threads = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--segments":
+                    segments = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--chunks-per-segment":
+                    chunksPerSegment = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--miss-latency-ms":
+                    missLatencyMs = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--fetch-chunks":
+                    fetchChunks = Integer.parseInt(args[i + 1]);
+                    break;
+                case "--disk-path":
+                    diskPath = args[i + 1];
+                    break;
+                case "--hot-ratio":
+                    hotRatio = Double.parseDouble(args[i + 1]);
+                    break;
+                case "--warm-ratio":
+                    warmRatio = Double.parseDouble(args[i + 1]);
+                    break;
+                case "--hot-thread-ratio":
+                    hotThreadRatio = Double.parseDouble(args[i + 1]);
+                    break;
+                case "--warm-thread-ratio":
+                    warmThreadRatio = Double.parseDouble(args[i + 1]);
+                    break;
+                case "--cold-thread-ratio":
+                    coldThreadRatio = Double.parseDouble(args[i + 1]);
+                    break;
+                case "--random-thread-ratio":
+                    randomThreadRatio = Double.parseDouble(args[i + 1]);
+                    break;
+                case "--prefill":
+                    prefill = Boolean.parseBoolean(args[i + 1]);
+                    break;
+                default:
+                    System.err.println("Unknown option: " + args[i]);
+                    System.exit(1);
+            }
+        }
+
+        return new Config(cacheType, cacheSize, chunkSize, duration, threads,
+            segments, chunksPerSegment, missLatencyMs, fetchChunks, prefill,
+            diskPath, hotRatio, warmRatio,
+            hotThreadRatio, warmThreadRatio, coldThreadRatio, randomThreadRatio);
+    }
+}

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -56,6 +56,7 @@
     <suppress checks="CyclomaticComplexity" files="ParquetAvroValueReaders.java"/>
     <suppress checks="CyclomaticComplexity" files="RecordConverter.java"/>
     <suppress checks="CyclomaticComplexity" files="SchemaUtils.java"/>
+    <suppress checks="CyclomaticComplexity" files=".*Bench\.java"/>
     <suppress checks="NPathComplexity" files="SingleBrokerTest.java"/>
     <suppress checks="JavaNCSSCheck" files="MetricsRegistry.java"/>
     <suppress checks="JavaNCSSCheck" files="RemoteStorageManagerMetricsTest.java"/>
@@ -64,6 +65,7 @@
     <suppress checks="JavaNCSSCheck" files="ParquetAvroValueReaders.java"/>
     <suppress checks="JavaNCSSCheck" files=".*Docs\.java"/>
     <suppress checks="JavaNCSSCheck" files="BatchEnumerationTest.java"/>
+    <suppress checks="JavaNCSSCheck" files=".*Bench\.java"/>
     <suppress checks="ParameterNumber" files="BatchEnumerationTest.java"/>
     <suppress checks="NPathComplexity" files="CredentialsBuilder.java"/>
     <suppress checks="NPathComplexity" files="ParquetAvroValueReaders.java"/>

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ByteBufferInputStream.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ByteBufferInputStream.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+class ByteBufferInputStream extends InputStream {
+    private final RefCountedByteBuffer source;
+    private final ByteBuffer buffer;
+    private boolean closed;
+
+    ByteBufferInputStream(final RefCountedByteBuffer source) {
+        this.source = source;
+        this.buffer = source.duplicate();
+    }
+
+    @Override
+    public int read() {
+        if (closed || !buffer.hasRemaining()) {
+            return -1;
+        }
+        return buffer.get() & 0xFF;
+    }
+
+    @Override
+    public int read(final byte[] bytes, final int offset, final int length) {
+        Objects.checkFromIndexSize(offset, length, bytes.length);
+        if (length == 0) {
+            return 0;
+        }
+        if (closed || !buffer.hasRemaining()) {
+            return -1;
+        }
+        final int bytesToRead = Math.min(length, buffer.remaining());
+        buffer.get(bytes, offset, bytesToRead);
+        return bytesToRead;
+    }
+
+    @Override
+    public long skip(final long n) {
+        if (closed || n <= 0) {
+            return 0;
+        }
+        final int bytesToSkip = (int) Math.min(n, buffer.remaining());
+        buffer.position(buffer.position() + bytesToSkip);
+        return bytesToSkip;
+    }
+
+    @Override
+    public int available() {
+        if (closed) {
+            return 0;
+        }
+        return buffer.remaining();
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            source.release();
+        }
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/ChunkCache.java
@@ -45,6 +45,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import com.github.benmanes.caffeine.cache.Weigher;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 
 public abstract class ChunkCache<T> implements ChunkManager, Configurable {
     public static final String METRIC_GROUP = "chunk-cache-metrics";
@@ -80,33 +81,33 @@ public abstract class ChunkCache<T> implements ChunkManager, Configurable {
         startPrefetching(objectKey, manifest, currentChunk.originalPosition + currentChunk.originalSize);
         final ChunkKey chunkKey = new ChunkKey(objectKey.value(), chunkId);
         final AtomicReference<InputStream> result = new AtomicReference<>();
-        try {
-            return cache.asMap()
-                .compute(chunkKey, (key, val) -> CompletableFuture.supplyAsync(() -> {
-                    if (val != null && !val.isCompletedExceptionally()) {
-                        statsCounter.recordHit();
-                        try {
-                            final T cachedChunk = val.get();
-                            result.getAndSet(cachedChunkToInputStream(cachedChunk));
-                            return cachedChunk;
-                        } catch (final InterruptedException | ExecutionException e) {
-                            throw new CompletionException(e);
-                        }
-                    } else {
-                        statsCounter.recordMiss();
-                        try {
-                            final InputStream chunk =
-                                    chunkManager.getChunk(objectKey, manifest, chunkId);
-                            final T t = this.cacheChunk(chunkKey, chunk);
-                            result.getAndSet(cachedChunkToInputStream(t));
-                            return t;
-                        } catch (final StorageBackendException | IOException e) {
-                            throw new CompletionException(e);
-                        }
+        final CompletableFuture<InputStream> resultFuture = cache.asMap()
+            .compute(chunkKey, (key, val) -> CompletableFuture.supplyAsync(() -> {
+                if (val != null && !val.isCompletedExceptionally()) {
+                    statsCounter.recordHit();
+                    try {
+                        final T cachedChunk = val.get();
+                        result.getAndSet(cachedChunkToInputStream(cachedChunk));
+                        return cachedChunk;
+                    } catch (final InterruptedException | ExecutionException e) {
+                        throw new CompletionException(e);
                     }
-                }, executor))
-                .thenApplyAsync(t -> result.get())
-                .get(getTimeout.toMillis(), TimeUnit.MILLISECONDS);
+                } else {
+                    statsCounter.recordMiss();
+                    try {
+                        final InputStream chunk =
+                                chunkManager.getChunk(objectKey, manifest, chunkId);
+                        final T t = this.cacheChunk(chunkKey, chunk);
+                        result.getAndSet(cachedChunkToInputStream(t));
+                        return t;
+                    } catch (final StorageBackendException | IOException e) {
+                        throw new CompletionException(e);
+                    }
+                }
+            }, executor))
+            .thenApply(t -> result.get());
+        try {
+            return resultFuture.get(getTimeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (final ExecutionException e) {
             // Unwrap previously wrapped exceptions if possible.
             final Throwable cause = e.getCause();
@@ -124,7 +125,30 @@ public abstract class ChunkCache<T> implements ChunkManager, Configurable {
 
             throw new RuntimeException(e);
         } catch (final InterruptedException | TimeoutException e) {
+            closeResultWhenAvailable(e, resultFuture, result);
             throw new RuntimeException(e);
+        }
+    }
+
+    private void closeResultWhenAvailable(final Exception e,
+                                  final CompletableFuture<?> resultFuture,
+                                  final AtomicReference<InputStream> result) {
+        if (e instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
+        // The worker may still be materialising the stream; close it once the future settles
+        // so the buffer it holds is released instead of leaked on an aborted get.
+        resultFuture.whenComplete((ignored, error) -> closeResult(result));
+    }
+
+    private void closeResult(final AtomicReference<InputStream> result) {
+        final InputStream stream = result.getAndSet(null);
+        if (stream != null) {
+            try {
+                stream.close();
+            } catch (final IOException ignored) {
+                // The stream was abandoned because getChunk failed before returning it to the caller.
+            }
         }
     }
 
@@ -154,6 +178,14 @@ public abstract class ChunkCache<T> implements ChunkManager, Configurable {
         statsCounter.registerSizeMetric(cache.synchronous()::estimatedSize);
 
         return cache;
+    }
+
+    public CacheStats cacheStats() {
+        return statsCounter.snapshot();
+    }
+
+    public long estimatedSize() {
+        return cache.synchronous().estimatedSize();
     }
 
     private void startPrefetching(final ObjectKey segmentKey,

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectByteBufferPool.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectByteBufferPool.java
@@ -26,6 +26,8 @@ public class DirectByteBufferPool {
 
     private final ConcurrentLinkedQueue<ByteBuffer> pool = new ConcurrentLinkedQueue<>();
     private final AtomicLong poolCount = new AtomicLong(0);
+    private final AtomicLong activeCount = new AtomicLong(0);
+    private final AtomicLong totalAllocatedBytes = new AtomicLong(0);
 
     public DirectByteBufferPool(final int bufferSize, final long maxPoolSize) {
         this.bufferSize = bufferSize;
@@ -36,23 +38,36 @@ public class DirectByteBufferPool {
         return bufferSize;
     }
 
-    public ByteBuffer get(final int bufferSize) {
-        if (bufferSize != this.bufferSize) {
-            return ByteBuffer.allocateDirect(bufferSize);
+    /**
+     * Acquire a direct buffer of at least the requested size.
+     * Returns a result indicating whether the buffer was reused from the pool or freshly allocated.
+     */
+    public PoolGetResult get(final int requestedSize) {
+        activeCount.incrementAndGet();
+        if (requestedSize != this.bufferSize) {
+            totalAllocatedBytes.addAndGet(requestedSize);
+            return new PoolGetResult(ByteBuffer.allocateDirect(requestedSize), false);
         }
 
         final ByteBuffer buf = pool.poll();
         if (buf != null) {
             poolCount.decrementAndGet();
             buf.clear();
-            return buf;
+            return new PoolGetResult(buf, true);
         }
 
-        return ByteBuffer.allocateDirect(this.bufferSize);
+        totalAllocatedBytes.addAndGet(this.bufferSize);
+        return new PoolGetResult(ByteBuffer.allocateDirect(this.bufferSize), false);
     }
 
     public void returnBuffer(final ByteBuffer buf) {
-        if (buf == null || !buf.isDirect() || buf.capacity() != this.bufferSize) {
+        if (buf == null || !buf.isDirect()) {
+            return;
+        }
+
+        activeCount.decrementAndGet();
+
+        if (buf.capacity() != this.bufferSize) {
             return;
         }
 
@@ -70,5 +85,20 @@ public class DirectByteBufferPool {
 
     public long currentPoolSize() {
         return poolCount.get();
+    }
+
+    public long maxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public long activeCount() {
+        return activeCount.get();
+    }
+
+    public long totalAllocatedBytes() {
+        return totalAllocatedBytes.get();
+    }
+
+    public record PoolGetResult(ByteBuffer buffer, boolean poolHit) {
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectByteBufferPool.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectByteBufferPool.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class DirectByteBufferPool {
+    private final int bufferSize;  // must equal with chunk size
+    private final long maxPoolSize;  // should be chunk cache size / chunk size
+
+    private final ConcurrentLinkedQueue<ByteBuffer> pool = new ConcurrentLinkedQueue<>();
+    private final AtomicLong poolCount = new AtomicLong(0);
+
+    public DirectByteBufferPool(final int bufferSize, final long maxPoolSize) {
+        this.bufferSize = bufferSize;
+        this.maxPoolSize = maxPoolSize;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public ByteBuffer get(final int bufferSize) {
+        if (bufferSize != this.bufferSize) {
+            return ByteBuffer.allocateDirect(bufferSize);
+        }
+
+        final ByteBuffer buf = pool.poll();
+        if (buf != null) {
+            poolCount.decrementAndGet();
+            buf.clear();
+            return buf;
+        }
+
+        return ByteBuffer.allocateDirect(this.bufferSize);
+    }
+
+    public void returnBuffer(final ByteBuffer buf) {
+        if (buf == null || !buf.isDirect() || buf.capacity() != this.bufferSize) {
+            return;
+        }
+
+        long current;
+        do {
+            current = poolCount.get();
+            if (current >= maxPoolSize) {
+                return;
+            }
+        } while (!poolCount.compareAndSet(current, current + 1));
+
+        buf.clear();
+        pool.offer(buf);
+    }
+
+    public long currentPoolSize() {
+        return poolCount.get();
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCache.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import io.aiven.kafka.tieredstorage.config.ChunkCacheConfig;
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
+
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.github.benmanes.caffeine.cache.Weigher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DirectMemoryChunkCache extends ChunkCache<RefCountedByteBuffer> {
+    private static final Logger log = LoggerFactory.getLogger(DirectMemoryChunkCache.class);
+
+    private static final int DEFAULT_BUFFER_SIZE = 4 * 1024 * 1024;
+    private static final long DEFAULT_MAX_POOL_SIZE = 512;
+
+    private DirectByteBufferPool bufferPool;
+
+    public DirectMemoryChunkCache(final ChunkManager chunkManager) {
+        super(chunkManager);
+    }
+
+    @Override
+    public InputStream cachedChunkToInputStream(final RefCountedByteBuffer cachedChunk) {
+        cachedChunk.retain();
+        return new ByteBufferInputStream(cachedChunk);
+    }
+
+    @Override
+    public RefCountedByteBuffer cacheChunk(final ChunkKey chunkKey, final InputStream chunk) throws IOException {
+        try (chunk) {
+            final byte[] bytes = chunk.readAllBytes();
+            final ByteBuffer directBuffer;
+            if (bytes.length <= bufferPool.getBufferSize()) {
+                directBuffer = bufferPool.get(bufferPool.getBufferSize());
+            } else {
+                directBuffer = bufferPool.get(bytes.length);
+            }
+            directBuffer.clear();
+            directBuffer.put(bytes);
+            directBuffer.flip();
+            return new RefCountedByteBuffer(directBuffer, bufferPool);
+        }
+    }
+
+    @Override
+    public RemovalListener<ChunkKey, RefCountedByteBuffer> removalListener() {
+        return (key, content, cause) -> {
+            if (content != null) {
+                content.release();
+            }
+            log.debug("Evicted key {} from cache, cause: {}", key, cause);
+        };
+    }
+
+    @Override
+    public Weigher<ChunkKey, RefCountedByteBuffer> weigher() {
+        return (key, value) -> value.capacity();
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        final ChunkCacheConfig config = new ChunkCacheConfig(configs);
+
+        int bufferSize = DEFAULT_BUFFER_SIZE;
+        if (configs.containsKey("chunk.size")) {
+            bufferSize = Integer.parseInt(configs.get("chunk.size").toString());
+        }
+
+        long maxPoolSize = DEFAULT_MAX_POOL_SIZE;
+        if (config.cacheSize().isPresent()) {
+            maxPoolSize = config.cacheSize().get() / bufferSize;
+        }
+
+        log.info("DirectMemoryChunkCache: bufferSize={}, maxPoolSize={}", bufferSize, maxPoolSize);
+
+        this.bufferPool = new DirectByteBufferPool(bufferSize, maxPoolSize);
+        this.cache = buildCache(config);
+    }
+
+    public DirectByteBufferPool getBufferPool() {
+        return bufferPool;
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCache.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCache.java
@@ -37,6 +37,7 @@ public class DirectMemoryChunkCache extends ChunkCache<RefCountedByteBuffer> {
     private static final long DEFAULT_MAX_POOL_SIZE = 512;
 
     private DirectByteBufferPool bufferPool;
+    private DirectMemoryChunkCacheMetrics poolMetrics;
 
     public DirectMemoryChunkCache(final ChunkManager chunkManager) {
         super(chunkManager);
@@ -52,15 +53,12 @@ public class DirectMemoryChunkCache extends ChunkCache<RefCountedByteBuffer> {
     public RefCountedByteBuffer cacheChunk(final ChunkKey chunkKey, final InputStream chunk) throws IOException {
         try (chunk) {
             final byte[] bytes = chunk.readAllBytes();
-            final ByteBuffer directBuffer;
-            if (bytes.length <= bufferPool.getBufferSize()) {
-                directBuffer = bufferPool.get(bufferPool.getBufferSize());
-            } else {
-                directBuffer = bufferPool.get(bytes.length);
-            }
-            directBuffer.clear();
+            final int requestedSize = Math.max(bytes.length, bufferPool.getBufferSize());
+            final DirectByteBufferPool.PoolGetResult result = bufferPool.get(requestedSize);
+            final ByteBuffer directBuffer = result.buffer();
             directBuffer.put(bytes);
             directBuffer.flip();
+            poolMetrics.bufferAcquired(directBuffer.capacity(), result.poolHit());
             return new RefCountedByteBuffer(directBuffer, bufferPool);
         }
     }
@@ -98,6 +96,7 @@ public class DirectMemoryChunkCache extends ChunkCache<RefCountedByteBuffer> {
 
         this.bufferPool = new DirectByteBufferPool(bufferSize, maxPoolSize);
         this.cache = buildCache(config);
+        this.poolMetrics = new DirectMemoryChunkCacheMetrics(bufferPool);
     }
 
     public DirectByteBufferPool getBufferPool() {

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCacheMetrics.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCacheMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.io.Closeable;
+import java.util.List;
+
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.utils.Time;
+
+class DirectMemoryChunkCacheMetrics implements Closeable {
+    private static final String METRIC_GROUP = "direct-memory-chunk-cache-metrics";
+    private static final String METRIC_CONTEXT = "aiven.kafka.server.tieredstorage.cache";
+
+    private final Metrics metrics;
+    private final Sensor poolHits;
+    private final Sensor poolMisses;
+    private final Sensor acquireBytes;
+
+    DirectMemoryChunkCacheMetrics(final DirectByteBufferPool bufferPool) {
+        final JmxReporter reporter = new JmxReporter();
+
+        metrics = new Metrics(
+            new MetricConfig(), List.of(reporter), Time.SYSTEM,
+            new KafkaMetricsContext(METRIC_CONTEXT)
+        );
+
+        poolHits = createSensor("buffer-pool-hit");
+        poolMisses = createSensor("buffer-pool-miss");
+        acquireBytes = createSensor("buffer-pool-acquire-bytes");
+
+        metrics.addMetric(
+            metrics.metricName("buffer-pool-size", METRIC_GROUP, "Number of buffers currently in pool"),
+            (Gauge<Long>) (config, now) -> bufferPool.currentPoolSize()
+        );
+        metrics.addMetric(
+            metrics.metricName("buffer-pool-max-size", METRIC_GROUP, "Maximum pool capacity"),
+            (Gauge<Long>) (config, now) -> bufferPool.maxPoolSize()
+        );
+        metrics.addMetric(
+            metrics.metricName("buffer-pool-active-count", METRIC_GROUP,
+                "Number of buffers currently checked out from pool"),
+            (Gauge<Long>) (config, now) -> bufferPool.activeCount()
+        );
+        metrics.addMetric(
+            metrics.metricName("buffer-pool-allocated-bytes", METRIC_GROUP,
+                "Total bytes of direct memory allocated"),
+            (Gauge<Long>) (config, now) -> bufferPool.totalAllocatedBytes()
+        );
+    }
+
+    private Sensor createSensor(final String name) {
+        final Sensor sensor = metrics.sensor(name);
+        sensor.add(metrics.metricName(name + "-rate", METRIC_GROUP), new Rate());
+        sensor.add(metrics.metricName(name + "-total", METRIC_GROUP), new CumulativeSum());
+        return sensor;
+    }
+
+    void bufferAcquired(final long bytes, final boolean poolHit) {
+        if (poolHit) {
+            poolHits.record(1);
+        } else {
+            poolMisses.record(1);
+        }
+        acquireBytes.record(bytes);
+    }
+
+    @Override
+    public void close() {
+        metrics.close();
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/RefCountedByteBuffer.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/fetch/cache/RefCountedByteBuffer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class RefCountedByteBuffer {
+    private final ByteBuffer buffer;
+    private final DirectByteBufferPool bufferPool;
+    private final AtomicInteger refCount = new AtomicInteger(1);
+
+    RefCountedByteBuffer(final ByteBuffer buffer, final DirectByteBufferPool bufferPool) {
+        this.buffer = buffer;
+        this.bufferPool = bufferPool;
+    }
+
+    ByteBuffer duplicate() {
+        return buffer.asReadOnlyBuffer();
+    }
+
+    int capacity() {
+        return buffer.capacity();
+    }
+
+    void retain() {
+        final int count = refCount.incrementAndGet();
+        if (count <= 1) {
+            refCount.decrementAndGet();
+            throw new IllegalStateException("Cannot retain a released buffer");
+        }
+    }
+
+    void release() {
+        final int count = refCount.decrementAndGet();
+        if (count == 0) {
+            bufferPool.returnBuffer(buffer);
+        } else if (count < 0) {
+            throw new IllegalStateException("Buffer already fully released");
+        }
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ByteBufferInputStreamTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/ByteBufferInputStreamTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ByteBufferInputStreamTest {
+    private static final int CHUNK_SIZE = 10;
+    private static final byte[] CHUNK_0 = "0123456789".getBytes();
+
+    @Test
+    void readsAllBytes() throws IOException {
+        try (InputStream is = new ByteBufferInputStream(newRefCountedBuffer(CHUNK_0))) {
+            assertThat(is).hasBinaryContent(CHUNK_0);
+        }
+    }
+
+    @Test
+    void singleByteReadReturnsUnsignedByte() throws IOException {
+        final RefCountedByteBuffer ref = newRefCountedBuffer(new byte[] {(byte) 0xFF, 0x00});
+        try (InputStream is = new ByteBufferInputStream(ref)) {
+            assertThat(is.read()).isEqualTo(0xFF);
+            assertThat(is.read()).isZero();
+            assertThat(is.read()).isEqualTo(-1);
+        }
+    }
+
+    @Test
+    void partialReadReturnsRequestedLength() throws IOException {
+        try (InputStream is = new ByteBufferInputStream(newRefCountedBuffer(CHUNK_0))) {
+            final byte[] dst = new byte[4];
+            assertThat(is.read(dst, 0, 4)).isEqualTo(4);
+            assertThat(dst).containsExactly('0', '1', '2', '3');
+        }
+    }
+
+    @Test
+    void zeroLengthReadReturnsZeroWhileDataRemains() throws IOException {
+        // InputStream contract: a len==0 read must return 0 (not -1) even when data is available.
+        // Pinning this guards the readByte-loop semantics used by Utils.readFully.
+        try (InputStream is = new ByteBufferInputStream(newRefCountedBuffer(CHUNK_0))) {
+            assertThat(is.read(new byte[4], 0, 0)).isZero();
+            assertThat(is.available()).isEqualTo(CHUNK_0.length);
+        }
+    }
+
+    @Test
+    void skipAndAvailable() throws IOException {
+        try (InputStream is = new ByteBufferInputStream(newRefCountedBuffer(CHUNK_0))) {
+            assertThat(is.available()).isEqualTo(10);
+            assertThat(is.skip(3)).isEqualTo(3);
+            assertThat(is.available()).isEqualTo(7);
+            assertThat(is.read()).isEqualTo('3');
+            assertThat(is.skip(100)).isEqualTo(6); // clamped to remaining
+            assertThat(is.read()).isEqualTo(-1);
+        }
+    }
+
+    @Test
+    void closeReleasesBufferToPool() throws IOException {
+        final DirectByteBufferPool pool = new DirectByteBufferPool(CHUNK_SIZE, 16);
+        final InputStream is = new ByteBufferInputStream(newRefCountedBuffer(pool, CHUNK_0));
+        assertThat(pool.currentPoolSize()).isZero();
+        is.close();
+        assertThat(pool.currentPoolSize()).isEqualTo(1);
+        // Reading after close yields EOF and close is idempotent.
+        assertThat(is.read()).isEqualTo(-1);
+        is.close();
+        assertThat(pool.currentPoolSize()).isEqualTo(1);
+    }
+
+    private static RefCountedByteBuffer newRefCountedBuffer(final byte[] data) {
+        return newRefCountedBuffer(new DirectByteBufferPool(data.length, 16), data);
+    }
+
+    private static RefCountedByteBuffer newRefCountedBuffer(final DirectByteBufferPool pool, final byte[] data) {
+        final ByteBuffer buffer = pool.get(data.length).buffer();
+        buffer.put(data);
+        buffer.flip();
+        return new RefCountedByteBuffer(buffer, pool);
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCacheTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/DirectMemoryChunkCacheTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType;
+
+import io.aiven.kafka.tieredstorage.fetch.ChunkKey;
+import io.aiven.kafka.tieredstorage.fetch.ChunkManager;
+import io.aiven.kafka.tieredstorage.manifest.SegmentIndexesV1;
+import io.aiven.kafka.tieredstorage.manifest.SegmentManifest;
+import io.aiven.kafka.tieredstorage.manifest.SegmentManifestV1;
+import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
+import io.aiven.kafka.tieredstorage.storage.ObjectKey;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DirectMemoryChunkCacheTest {
+    private static final int CHUNK_SIZE = 10;
+    private static final byte[] CHUNK_0 = "0123456789".getBytes();
+    private static final byte[] CHUNK_1 = "abcdefghij".getBytes();
+    private static final ObjectKey SEGMENT_OBJECT_KEY = () -> "topic/segment";
+    private static final SegmentIndexesV1 SEGMENT_INDEXES = SegmentIndexesV1.builder()
+        .add(IndexType.OFFSET, 1)
+        .add(IndexType.TIMESTAMP, 1)
+        .add(IndexType.PRODUCER_SNAPSHOT, 1)
+        .add(IndexType.LEADER_EPOCH, 1)
+        .add(IndexType.TRANSACTION, 1)
+        .build();
+    private static final SegmentManifest SEGMENT_MANIFEST = new SegmentManifestV1(
+        new FixedSizeChunkIndex(CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE, CHUNK_SIZE),
+        SEGMENT_INDEXES,
+        false,
+        null,
+        null
+    );
+    private static final SegmentManifest TWO_CHUNK_MANIFEST = new SegmentManifestV1(
+        new FixedSizeChunkIndex(CHUNK_SIZE, CHUNK_SIZE * 2, CHUNK_SIZE, CHUNK_SIZE),
+        SEGMENT_INDEXES,
+        false,
+        null,
+        null
+    );
+
+    @Mock
+    private ChunkManager chunkManager;
+
+    private DirectMemoryChunkCache chunkCache;
+
+    @Test
+    void cacheMissReadsFromChunkManager() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+
+        chunkCache = newCache(cacheConfig());
+
+        try (InputStream chunk = chunkCache.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0)) {
+            assertThat(chunk).hasBinaryContent(CHUNK_0);
+        }
+
+        final var stats = chunkCache.cacheStats();
+        assertThat(stats.missCount()).isEqualTo(1);
+        assertThat(stats.hitCount()).isZero();
+    }
+
+    @Test
+    void cacheHitReturnsCachedDataWithoutRefetching() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+
+        chunkCache = newCache(cacheConfig());
+
+        try (InputStream first = chunkCache.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0)) {
+            assertThat(first).hasBinaryContent(CHUNK_0);
+        }
+        try (InputStream second = chunkCache.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0)) {
+            assertThat(second).hasBinaryContent(CHUNK_0);
+        }
+
+        verify(chunkManager, times(1)).getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0);
+        assertThat(chunkCache.cacheStats().hitCount()).isEqualTo(1);
+    }
+
+    @Test
+    void weigherReturnsBufferCapacity() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+
+        chunkCache = newCache(cacheConfig());
+
+        try (InputStream chunk = chunkCache.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0)) {
+            assertThat(chunk).hasBinaryContent(CHUNK_0);
+        }
+
+        // The weigher drives size-based eviction; it must report the buffer capacity.
+        final ChunkKey key = new ChunkKey(SEGMENT_OBJECT_KEY.value(), 0);
+        final RefCountedByteBuffer cached = chunkCache.cache.synchronous().getIfPresent(key);
+        assertThat(cached).isNotNull();
+        assertThat(chunkCache.weigher().weigh(key, cached)).isEqualTo(CHUNK_SIZE);
+    }
+
+    @Test
+    void oversizedChunkAllocatesLargerBufferThatBypassesPool() throws Exception {
+        final byte[] oversizedData = "01234567890123456789".getBytes();
+        final SegmentManifest oversizedManifest = new SegmentManifestV1(
+            new FixedSizeChunkIndex(20, 20, 20, 20),
+            SEGMENT_INDEXES,
+            false,
+            null,
+            null
+        );
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, oversizedManifest, 0))
+            .thenReturn(new ByteArrayInputStream(oversizedData));
+
+        chunkCache = newCache(Map.of(
+            "retention.ms", "-1",
+            "size", "100",
+            "chunk.size", String.valueOf(CHUNK_SIZE),
+            "thread.pool.size", "1"
+        ));
+
+        try (InputStream chunk = chunkCache.getChunk(SEGMENT_OBJECT_KEY, oversizedManifest, 0)) {
+            assertThat(chunk).hasBinaryContent(oversizedData);
+        }
+
+        // Buffer larger than chunk.size must not be pooled on release.
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() ->
+            assertThat(chunkCache.getBufferPool().currentPoolSize()).isZero());
+    }
+
+    @Test
+    void evictionReleasesBufferToPool() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 1))
+            .thenReturn(new ByteArrayInputStream(CHUNK_1));
+
+        // Cache holds a single chunk; the second read evicts the first.
+        chunkCache = newCache(cacheConfig());
+
+        try (InputStream chunk = chunkCache.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 0)) {
+            assertThat(chunk).hasBinaryContent(CHUNK_0);
+        }
+        try (InputStream chunk = chunkCache.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 1)) {
+            assertThat(chunk).hasBinaryContent(CHUNK_1);
+        }
+
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+            assertThat(chunkCache.getBufferPool().currentPoolSize()).isPositive());
+    }
+
+    @Test
+    void refCountPreventsPoolReturnWhileStreamOpen() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 1))
+            .thenReturn(new ByteArrayInputStream(CHUNK_1));
+
+        chunkCache = newCache(cacheConfig());
+
+        final InputStream openStream = chunkCache.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 0);
+
+        // Reading the second chunk evicts the first, but its buffer must stay out of the
+        // pool while the first stream is still open (otherwise: use-after-free).
+        try (InputStream chunk = chunkCache.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 1)) {
+            assertThat(chunk).hasBinaryContent(CHUNK_1);
+        }
+
+        await().atMost(Duration.ofSeconds(2)).pollDelay(Duration.ofMillis(100)).untilAsserted(() ->
+            assertThat(chunkCache.estimatedSize()).isLessThanOrEqualTo(1));
+        assertThat(chunkCache.getBufferPool().currentPoolSize()).isZero();
+
+        openStream.close();
+
+        await().atMost(Duration.ofSeconds(1)).untilAsserted(() ->
+            assertThat(chunkCache.getBufferPool().currentPoolSize()).isEqualTo(1));
+    }
+
+    @Test
+    void concurrentReadersOnSameKeyReleaseBufferExactlyOnce() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+
+        // Single-entry cache; many readers retain/release the same buffer concurrently.
+        chunkCache = newCache(cacheConfig());
+
+        final int threadCount = 8;
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+        final List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            final Thread t = new Thread(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    for (int r = 0; r < 50; r++) {
+                        try (InputStream chunk =
+                                 chunkCache.getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0)) {
+                            assertThat(chunk).hasBinaryContent(CHUNK_0);
+                        }
+                    }
+                } catch (final Throwable e) {
+                    errors.add(e);
+                }
+            });
+            threads.add(t);
+            t.start();
+        }
+        for (final Thread t : threads) {
+            t.join(15_000);
+        }
+
+        assertThat(errors).isEmpty();
+        // Entry still cached and held by exactly one (cache) reference: not yet in the pool.
+        assertThat(chunkCache.getBufferPool().currentPoolSize()).isZero();
+        verify(chunkManager, times(1)).getChunk(SEGMENT_OBJECT_KEY, SEGMENT_MANIFEST, 0);
+    }
+
+    @Test
+    void concurrentReadsOnDifferentKeys() throws Exception {
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 0))
+            .thenReturn(new ByteArrayInputStream(CHUNK_0));
+        when(chunkManager.getChunk(SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, 1))
+            .thenReturn(new ByteArrayInputStream(CHUNK_1));
+
+        chunkCache = newCache(Map.of(
+            "retention.ms", "-1",
+            "size", String.valueOf(CHUNK_SIZE * 2),
+            "chunk.size", String.valueOf(CHUNK_SIZE),
+            "thread.pool.size", "2"
+        ));
+
+        final int threadCount = 2;
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+        final List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            final int chunkId = i;
+            final byte[] expected = chunkId == 0 ? CHUNK_0 : CHUNK_1;
+            final Thread t = new Thread(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    try (InputStream chunk = chunkCache.getChunk(
+                        SEGMENT_OBJECT_KEY, TWO_CHUNK_MANIFEST, chunkId)) {
+                        assertThat(chunk).hasBinaryContent(expected);
+                    }
+                } catch (final Throwable e) {
+                    errors.add(e);
+                }
+            });
+            threads.add(t);
+            t.start();
+        }
+        for (final Thread t : threads) {
+            t.join(10_000);
+        }
+
+        assertThat(errors).isEmpty();
+    }
+
+    private DirectMemoryChunkCache newCache(final Map<String, ?> config) {
+        final DirectMemoryChunkCache cache = new DirectMemoryChunkCache(chunkManager);
+        cache.configure(config);
+        return cache;
+    }
+
+    private static Map<String, String> cacheConfig() {
+        return Map.of(
+            "retention.ms", "-1",
+            "size", String.valueOf(CHUNK_SIZE),
+            "chunk.size", String.valueOf(CHUNK_SIZE),
+            "thread.pool.size", "1"
+        );
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/RefCountedByteBufferTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/fetch/cache/RefCountedByteBufferTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.fetch.cache;
+
+import java.nio.ByteBuffer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RefCountedByteBufferTest {
+    private static final int CHUNK_SIZE = 10;
+    private static final byte[] CHUNK_0 = "0123456789".getBytes();
+
+    @Test
+    void releaseReturnsBufferToPoolExactlyOnce() {
+        final DirectByteBufferPool pool = new DirectByteBufferPool(CHUNK_SIZE, 16);
+        final RefCountedByteBuffer ref = newRefCountedBuffer(pool, CHUNK_0);
+
+        assertThat(pool.currentPoolSize()).isZero();
+        ref.release(); // initial refcount of 1 -> 0, returns to pool
+        assertThat(pool.currentPoolSize()).isEqualTo(1);
+    }
+
+    @Test
+    void retainPreventsReturnUntilAllReleased() {
+        final DirectByteBufferPool pool = new DirectByteBufferPool(CHUNK_SIZE, 16);
+        final RefCountedByteBuffer ref = newRefCountedBuffer(pool, CHUNK_0);
+
+        ref.retain(); // 1 -> 2
+        ref.release(); // 2 -> 1, not yet returned
+        assertThat(pool.currentPoolSize()).isZero();
+        ref.release(); // 1 -> 0, returned
+        assertThat(pool.currentPoolSize()).isEqualTo(1);
+    }
+
+    @Test
+    void retainAfterFullReleaseThrows() {
+        final RefCountedByteBuffer ref = newRefCountedBuffer(CHUNK_0);
+        ref.release(); // -> 0
+        assertThatThrownBy(ref::retain)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Cannot retain a released buffer");
+    }
+
+    @Test
+    void overReleaseThrows() {
+        final RefCountedByteBuffer ref = newRefCountedBuffer(CHUNK_0);
+        ref.release(); // -> 0
+        assertThatThrownBy(ref::release)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Buffer already fully released");
+    }
+
+    private static RefCountedByteBuffer newRefCountedBuffer(final byte[] data) {
+        return newRefCountedBuffer(new DirectByteBufferPool(data.length, 16), data);
+    }
+
+    private static RefCountedByteBuffer newRefCountedBuffer(final DirectByteBufferPool pool, final byte[] data) {
+        final ByteBuffer buffer = pool.get(data.length).buffer();
+        buffer.put(data);
+        buffer.flip();
+        return new RefCountedByteBuffer(buffer, pool);
+    }
+}

--- a/e2e/src/integration-test/java/io/aiven/kafka/tieredstorage/e2e/DirectMemoryCacheLocalSystemTest.java
+++ b/e2e/src/integration-test/java/io/aiven/kafka/tieredstorage/e2e/DirectMemoryCacheLocalSystemTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.e2e;
+
+import java.io.IOException;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import com.github.dockerjava.api.model.Ports;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * E2E test using DirectMemoryChunkCache with FileSystem backend.
+ * Validates all standard tiered storage scenarios plus direct memory leak detection.
+ */
+public class DirectMemoryCacheLocalSystemTest extends LocalSystemSingleBrokerTest {
+    static final long CACHE_SIZE = 16L * 1024 * 1024; // 16MB
+    static final int JMX_PORT = 9999;
+
+    @BeforeAll
+    static void init() throws Exception {
+        setupKafka(kafka -> {
+            tieredDataDir = baseDir.resolve(TS_DATA_SUBDIR_HOST);
+            tieredDataDir.toFile().mkdirs();
+            tieredDataDir.toFile().setWritable(true, false);
+
+            kafka
+                .withEnv("KAFKA_REMOTE_LOG_STORAGE_MANAGER_CLASS_PATH",
+                    "/tiered-storage-for-apache-kafka/core/*")
+                .withEnv("KAFKA_RSM_CONFIG_STORAGE_BACKEND_CLASS",
+                    "io.aiven.kafka.tieredstorage.storage.filesystem.FileSystemStorage")
+                .withEnv("KAFKA_RSM_CONFIG_STORAGE_ROOT", TS_DATA_DIR_CONTAINER)
+                .withFileSystemBind(tieredDataDir.toString(), TS_DATA_DIR_CONTAINER)
+                // DirectMemoryChunkCache configuration
+                .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_CLASS",
+                    "io.aiven.kafka.tieredstorage.fetch.cache.DirectMemoryChunkCache")
+                .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_SIZE",
+                    Long.toString(CACHE_SIZE))
+                .withEnv("KAFKA_RSM_CONFIG_FETCH_CHUNK_CACHE_CHUNK_SIZE",
+                    Integer.toString(CHUNK_SIZE))
+                .withEnv("KAFKA_OPTS", "-Djava.rmi.server.hostname=localhost")
+                // Enable JMX remote access
+                .withEnv("KAFKA_JMX_PORT", Integer.toString(JMX_PORT))
+                .withEnv("KAFKA_JMX_HOSTNAME", "localhost");
+            kafka.addExposedPort(JMX_PORT);
+            kafka.withCreateContainerCmdModifier(cmd -> {
+                final Ports ports = cmd.getHostConfig().getPortBindings();
+                ports.bind(new com.github.dockerjava.api.model.ExposedPort(JMX_PORT),
+                    Ports.Binding.bindPort(JMX_PORT));
+                cmd.getHostConfig().withPortBindings(ports);
+            });
+        });
+    }
+
+    @Test
+    @Order(6)
+    void verifyPoolMetricsAndNoLeak() throws Exception {
+        // After all topics are deleted (Order 5), wait for async eviction.
+        Thread.sleep(3000);
+
+        final String pid = getKafkaPid();
+        triggerGC(pid);
+
+        try (JMXConnector connector = connectJmx()) {
+            final MBeanServerConnection mbs = connector.getMBeanServerConnection();
+
+            // --- DirectMemoryChunkCacheMetrics (buffer pool) ---
+            final ObjectName poolObj = new ObjectName(
+                "aiven.kafka.server.tieredstorage.cache:type=direct-memory-chunk-cache-metrics");
+
+            final long activeCount = ((Number) mbs.getAttribute(poolObj, "buffer-pool-active-count")).longValue();
+            final long poolSize = ((Number) mbs.getAttribute(poolObj, "buffer-pool-size")).longValue();
+            final long maxSize = ((Number) mbs.getAttribute(poolObj, "buffer-pool-max-size")).longValue();
+            final long allocatedBytes =
+                ((Number) mbs.getAttribute(poolObj, "buffer-pool-allocated-bytes")).longValue();
+            final double hitTotal = ((Number) mbs.getAttribute(poolObj, "buffer-pool-hit-total")).doubleValue();
+            final double missTotal = ((Number) mbs.getAttribute(poolObj, "buffer-pool-miss-total")).doubleValue();
+            final double hitRate = ((Number) mbs.getAttribute(poolObj, "buffer-pool-hit-rate")).doubleValue();
+            final double missRate = ((Number) mbs.getAttribute(poolObj, "buffer-pool-miss-rate")).doubleValue();
+            final double acquireBytesTotal =
+                ((Number) mbs.getAttribute(poolObj, "buffer-pool-acquire-bytes-total")).doubleValue();
+            final double acquireBytesRate =
+                ((Number) mbs.getAttribute(poolObj, "buffer-pool-acquire-bytes-rate")).doubleValue();
+
+            LOG.info("Pool Gauges: activeCount={}, poolSize={}, maxSize={}, allocatedBytes={}",
+                activeCount, poolSize, maxSize, allocatedBytes);
+            LOG.info("Pool Sensors: hitTotal={}, missTotal={}, acquireBytesTotal={}, hitRate={}, missRate={}, "
+                    + "acquireBytesRate={}", hitTotal, missTotal, acquireBytesTotal, hitRate, missRate,
+                acquireBytesRate);
+
+            // --- CaffeineStatsCounter (cache-level) ---
+            final ObjectName cacheObj = new ObjectName(
+                "aiven.kafka.server.tieredstorage.cache:type=chunk-cache-metrics");
+            final double cacheSize = ((Number) mbs.getAttribute(cacheObj, "cache-size-total")).doubleValue();
+            LOG.info("Cache metrics: cacheSize={}", cacheSize);
+
+            // Leak detection: all active buffers must be accounted for by cache entries
+            assertThat(activeCount)
+                .as("Active buffers should equal cache size (no leak)")
+                .isEqualTo((long) cacheSize);
+
+            // Pool invariants
+            assertThat(poolSize).as("poolSize <= maxSize").isLessThanOrEqualTo(maxSize);
+            assertThat(allocatedBytes)
+                .as("Total allocated bytes bounded")
+                .isLessThanOrEqualTo(CACHE_SIZE + 8L * 1024 * 1024);
+
+            // Sensors recorded activity during the test
+            assertThat(hitTotal + missTotal).as("At least one acquire").isGreaterThan(0);
+            assertThat(hitTotal / (hitTotal + missTotal))
+                .as("Pool reuse ratio should be positive")
+                .isGreaterThan(0);
+            assertThat(acquireBytesTotal).as("Acquire bytes positive").isGreaterThan(0);
+            assertThat(hitRate).as("Hit rate non-negative").isGreaterThanOrEqualTo(0);
+            assertThat(missRate).as("Miss rate non-negative").isGreaterThanOrEqualTo(0);
+            assertThat(acquireBytesRate).as("Acquire bytes rate non-negative").isGreaterThanOrEqualTo(0);
+        }
+    }
+
+    @Test
+    @Order(7)
+    void jvmDirectMemoryBounded() throws Exception {
+        try (JMXConnector connector = connectJmx()) {
+            final MBeanServerConnection mbs = connector.getMBeanServerConnection();
+            final ObjectName directPoolName = new ObjectName("java.nio:type=BufferPool,name=direct");
+            final long directMemoryUsed = (Long) mbs.getAttribute(directPoolName, "MemoryUsed");
+            LOG.info("BufferPoolMXBean: memoryUsed={} bytes", directMemoryUsed);
+
+            assertThat(directMemoryUsed)
+                .as("JVM direct memory bounded by pool capacity + Kafka overhead")
+                .isLessThanOrEqualTo(CACHE_SIZE + 8L * 1024 * 1024);
+        }
+    }
+
+    private String getKafkaPid() throws Exception {
+        final var pidResult = kafka.execInContainer("bash", "-c", "pgrep -f kafka.Kafka || echo 1");
+        return pidResult.getStdout().trim().lines().findFirst().orElse("1");
+    }
+
+    private void triggerGC(final String pid) throws Exception {
+        kafka.execInContainer("bash", "-c", "jcmd " + pid + " GC.run 2>&1");
+        Thread.sleep(2000);
+    }
+
+    private JMXConnector connectJmx() throws IOException {
+        final String url = String.format(
+            "service:jmx:rmi:///jndi/rmi://localhost:%d/jmxrmi", JMX_PORT);
+        return JMXConnectorFactory.connect(new JMXServiceURL(url), null);
+    }
+}


### PR DESCRIPTION
Introduces a new ChunkCache implementation that stores chunks in
off-heap direct ByteBuffers with reference counting and buffer pooling.

- DirectByteBufferPool: pooled direct buffer allocation/recycling
- RefCountedByteBuffer: reference counting for safe concurrent access
- ByteBufferInputStream: InputStream over direct buffer
- DirectMemoryChunkCache: Caffeine cache integration with pool
- ChunkCacheScenarioBench: comprehensive benchmark for the ChunkCache implementations

Resolves: #830

There are some limitations:

  1. The buffer size in `DirectByteBufferPool` must equal the `chunk.size` configured at the higher level. However, since the `chunk.size` is not directly passed to `ChunkCache`, there
   is currently a redundant `fetch.chunk.cache.chunk.size` configuration.
  2. `DirectByteBufferPool` holds a fixed number of fixed-size buffers. Once expanded, it does not release memory back to the OS, even after cached entries have been evicted.
  3. The `InputStream` returned by `cachedChunkToInputStream` must be closed by the caller to return the buffer to `DirectByteBufferPool` for reuse. This must be guaranteed by
  the upper-layer caller.