### PR TITLE
[WIP] Backport: Convert escaping Throwable in copyLogSegmentData (0.0.1-SNAPSHOT shape)

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -264,6 +264,19 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                 log.warn("Removing orphan files failed", ex);
             }
             throw new RemoteStorageException(e);
+        } catch (final Throwable t) {
+            // Convert any escaping Throwable to a RemoteStorageException so it cannot bypass
+            // Kafka's RLMTask catch (Exception) clause and trip
+            // ScheduledThreadPoolExecutor.scheduleWithFixedDelay's silent-suppression rule.
+            // RemoteStorageException extends Exception, so the existing Kafka catch will
+            // swallow it and the scheduled task continues to retry on the next tick. See #820 / PR #833.
+            log.error("Copying log segment data failed, metadata: {}", remoteLogSegmentMetadata, t);
+            try {
+                deleteSegmentObjects(remoteLogSegmentMetadata);
+            } catch (final Exception ex) {
+                log.warn("Removing orphan files failed after wrapping Throwable", ex);
+            }
+            throw new RemoteStorageException(t);
         }
 
         metrics.recordSegmentCopyTime(


### PR DESCRIPTION
**Draft / WIP — not for merge as-is.**

This PR carries the same fix as #833 (Convert escaping Throwable in `copyLogSegmentData` to `RemoteStorageException`) but applied against the **0.0.1-SNAPSHOT method shape** that exists at tag [`2024-10-23-1729694047`](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases/tag/2024-10-23-1729694047) — the version we currently run in our QA Kafka brokers.

## Why two PRs

- `#833` targets current `main`, where `RemoteStorageManager.copyLogSegmentData` was refactored to delegate to a `KafkaRemoteStorageManager`. Cherry-picking `#833` onto the older 0.0.1-SNAPSHOT branch produces a merge conflict because the method body is structurally different.
- This branch is based on the older tag and applies the same semantic fix (outer `catch (Throwable)` → `throw new RemoteStorageException(t)`) directly inside the un-delegated upload chain.

## Why the diff looks like a revert of 284 commits

This PR's base branch is the tag `2024-10-23-1729694047`. Compared to current `main`, it's missing the ~284 commits that have landed since (including PR #797 and assorted dependabot bumps). **It is not actually meant to merge into `main`** — `main` already has all those commits. The diff is shown as deletions because git compares to `main`.

## What you actually want to review

Just the single new commit on top of the tag:

```
git --no-pager show eae6370 -- core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
```

The semantic change is identical to the catch-`Throwable` block already proposed in #833.

## Intended use

Build artifact for our QA clusters that match `0.0.1-SNAPSHOT` exactly (same dependency versions as the [2024-10-23 release](https://github.com/Aiven-Open/tiered-storage-for-apache-kafka/releases/tag/2024-10-23-1729694047)). The upstream fix that actually goes into `main` is #833.

## Status

WIP — keeping this open for internal review only. Will close once #833 lands and we cut a release built from a `main`-based artifact.

Refs #820, #833